### PR TITLE
IS-35 Name change of claims and scopes

### DIFF
--- a/claim-mappings-to-other-specs.md
+++ b/claim-mappings-to-other-specs.md
@@ -14,30 +14,30 @@ The following table defines a mapping from the SAML attribute names defined in "
 | Given name | urn:oid:2.5.4.42 (givenName) | `given_name` | \[[OpenID.Core](#openid-core)\] |  | 
 | Display (full) name | urn:oid:2.16.840.1.<br/>113730.3.1.241 (displayName) | `name` | \[[OpenID.Core](#openid-core)\] |   |
 | Gender | urn:oid:1.3.6.1.5.5.7.9.3 (gender) | `gender` | \[[OpenID.Core](#openid-core)\] | \[OpenID.Core\] defines possible values to be `female` and `male`. \[[SC.AttrSpec](#sc-attrspec)\] defines the possible values to be `M`/`m`, `F`/`f` and `U`/`u` (for unspecified). |
-| Swedish Personal Number | urn:oid:1.2.752.29.4.13 (personalIdentityNumber) | `https://claims.oidc.se/`<br/>`1.0/personalNumber` | \[[OIDC.Sweden](#oidc-sweden)\] | \[[SC.AttrSpec](#sc-attrspec)\] also uses the same attribute for a Swedish coordination number. \[[OIDC.Sweden](#oidc-sweden)\] defines this claim to be `https://claims.oidc.se/1.0/coordinationNumber`. |
-| previousPersonal-<br/>IdentityNumber | urn:oid:1.2.752.201.3.15<br />(previousPersonalIdentityNumber) | `https://claims.oidc.se`<br />`/1.0/previousPersonalNumber` | [[OIDC.Sweden](#oidc-sweden)\] |
+| Swedish Personal Number | urn:oid:1.2.752.29.4.13 (personalIdentityNumber) | `https://id.oidc.se/claim/`<br/>`personalIdentityNumber` | \[[OIDC.Sweden](#oidc-sweden)\] | \[[SC.AttrSpec](#sc-attrspec)\] also uses the same attribute for a Swedish coordination number. \[[OIDC.Sweden](#oidc-sweden)\] defines this claim to be `https://id.oidc.se/claim/coordinationNumber`. |
+| previousPersonal-<br/>IdentityNumber | urn:oid:1.2.752.201.3.15<br />(previousPersonalIdentityNumber) | `https://id.oidc.se/claim/`<br />`previousCoordinationNumber` | [[OIDC.Sweden](#oidc-sweden)\] | The OIDC-profile only handles coordination numbers. |
 | Date of birth | urn:oid:1.3.6.1.5.5.7.9.1 (dateOfBirth) | `birthdate` | \[[OpenID.Core](#openid-core)\] | The format (YYYY-MM-DD) is the same for both the dateOfBirth SAML-attribute and the `birthdate` claim. |
-| Name at the time of birth | urn:oid:1.2.752.201.3.8 (birthName) | `https://claims.oidc.se/`<br />`1.0/birthName`` | \[[OIDC.Sweden](#oidc-sweden)\] | |
+| Name at the time of birth | urn:oid:1.2.752.201.3.8 (birthName) | `https://id.oidc.se/claim/`<br />`birthName` | \[[OIDC.Sweden](#oidc-sweden)\] | |
 | Street address | urn:oid:2.5.4.9 (street) | `address.street_address` | \[[OpenID.Core](#openid-core)\] | Field of the `address` claim. |
 | Post office box | urn:oid:2.5.4.18 (postOfficeBox) | `address.street_address` | \[[OpenID.Core](#openid-core)\] | Field of the `address` claim. The `street_address` MAY include house number, street name, Post Office Box, and multi-line extended street address information.   |
 | Postal code | urn:oid:2.5.4.17 (postalCode) | `address.postal_code` | \[[OpenID.Core](#openid-core)\] | Field of the `address` claim. |
 | Locality | urn:oid:2.5.4.7 (l) | `address.locality` | \[[OpenID.Core](#openid-core)\] | Field of the `address` claim. |
-| Country | urn:oid:2.5.4.6 (c) | `address.country` or<br />`https://claims.oidc.se/`<br />`1.0/country` | \[[OpenID.Core](#openid-core)\]<br />\[[OIDC.Sweden](#oidc-sweden)\] | Depends on in which context country is to be represented. |
-| Place of birth | urn:oid:1.3.6.1.5.5.7.9.2 (placeOfBirth) | `https://claims.oidc.se/`<br />`1.0/placeOfbirth` | \[[OIDC.Sweden](#oidc-sweden)\] | |
+| Country | urn:oid:2.5.4.6 (c) | `address.country` or<br />`https://id.oidc.se/claim/`<br />`country` | \[[OpenID.Core](#openid-core)\]<br />\[[OIDC.Sweden](#oidc-sweden)\] | Depends on in which context country is to be represented. |
+| Place of birth | urn:oid:1.3.6.1.5.5.7.9.2 (placeOfBirth) | `https://id.oidc.se/claim/`<br />`placeOfbirth` | \[[OIDC.Sweden](#oidc-sweden)\] | |
 | Country of citizenship | urn:oid:1.3.6.1.5.5.7.9.4 (countryOfCitizenship) | - | - | No mapping exists at this moment. |
 | Country of Residence | urn:oid:1.3.6.1.5.5.7.9.5 (countryOfResidence) | - | - | No mapping exists at this moment. |
 | Telephone number | urn:oid:2.5.4.20 (telephoneNumber) | `phone_number` | \[[OpenID.Core](#openid-core)\] | See also `phone_number_verified`. |
 | Mobile number | urn:oid:0.9.2342.19200300.100.1.41 (mobile) | `phone_number` | \[[OpenID.Core](#openid-core)\] | No specific claim exists that make a difference between a landline phone and a mobile phone in \[[IANA-Reg](#iana-reg)\]. Is this necessary? |
 | E-mail address | urn:oid:0.9.2342.19200300.100.1.3 (mail) | `email` | \[[OpenID.Core](#openid-core)\] | See also `email_verified`. |
-| Organization name | urn:oid:2.5.4.10 (o) | `https://claims.oidc.se/`<br />`1.0/orgName` | \[[OIDC.Sweden](#oidc-sweden)\] |  |
-| Organizational unit name | urn:oid:2.5.4.11 (ou) | `https://claims.oidc.se/`<br />`1.0/orgUnit` | \[[OIDC.Sweden](#oidc-sweden)\] | |
-| Organizational identifier code | urn:oid:2.5.4.97 (organizationIdentifier) | `https://claims.oidc.se/`<br/>`1.0/orgNumber` | \[[OIDC.Sweden](#oidc-sweden)\] | |
-| Organizational Affiliation | urn:oid:1.2.752.201.3.1 (orgAffiliation) | `https://claims.oidc.se/`<br/>`1.0/orgAffiliation` | \[[OIDC.Sweden](#oidc-sweden)\] | |
+| Organization name | urn:oid:2.5.4.10 (o) | `https://id.oidc.se/claim/`<br />`orgName` | \[[OIDC.Sweden](#oidc-sweden)\] |  |
+| Organizational unit name | urn:oid:2.5.4.11 (ou) | `https://id.oidc.se/claim/`<br />`orgUnit` | \[[OIDC.Sweden](#oidc-sweden)\] | |
+| Organizational identifier code | urn:oid:2.5.4.97 (organizationIdentifier) | `https://id.oidc.se/claim/`<br/>`orgNumber` | \[[OIDC.Sweden](#oidc-sweden)\] | |
+| Organizational Affiliation | urn:oid:1.2.752.201.3.1 (orgAffiliation) | `https://id.oidc.se/claim/`<br/>`orgAffiliation` | \[[OIDC.Sweden](#oidc-sweden)\] | |
 | Transaction identifier | urn:oid:1.2.752.201.3.2 (transactionIdentifier) | `txn` | \[[RFC8417](#rfc8417)\] |
 | Authentication Context Parameters | urn:oid:1.2.752.201.3.3 (authContextParams) | - |  | This attribute will not be represented as a claim. However, some of the data that are normally put in this attribute are not claims of their own (credentialValidFrom, ...).|
-| User certificate | urn:oid:1.2.752.201.3.10 (userCertificate) | `https://claims.oidc.se`<br />`/1.0/userCertificate` | \[[OIDC.Sweden](#oidc-sweden)\] | |
-| User signature | urn:oid:1.2.752.201.3.11 (userSignature) | `https://claims.oidc.se/`<br />`1.0/userSignature` | \[[OIDC.Sweden](#oidc-sweden)\] | |
-| Authentication server signature | urn:oid:1.2.752.201.3.13 (authServerSignature) | `https://claims.oidc.se/`<br />`1.0/authnEvidence` | \[[OIDC.Sweden](#oidc-sweden)\] | |
+| User certificate | urn:oid:1.2.752.201.3.10 (userCertificate) | `https://id.oidc.se/claim/`<br />`userCertificate` | \[[OIDC.Sweden](#oidc-sweden)\] | |
+| User signature | urn:oid:1.2.752.201.3.11 (userSignature) | `https://id.oidc.se/claim/`<br />`userSignature` | \[[OIDC.Sweden](#oidc-sweden)\] | |
+| Authentication server signature | urn:oid:1.2.752.201.3.13 (authServerSignature) | `https://id.oidc.se/claim/`<br />`authnEvidence` | \[[OIDC.Sweden](#oidc-sweden)\] | |
 | Signature activation data | urn:oid:1.2.752.201.3.12 (sad) | - | - | No mapping exists - Will have to be handled in Sweden Connect's OpenID Connect profiles. |
 | Sign message digest | urn:oid:1.2.752.201.3.14 (signMessageDigest) | - | - | No mapping exists - Will have to be handled in Sweden Connect's OpenID Connect profiles. |
 | Provisional identifier | urn:oid:1.2.752.201.3.4 (prid) | - | - | eIDAS specific - Will have to be handled in Sweden Connect's OpenID Connect profiles. |
@@ -54,15 +54,15 @@ The following table defines a mapping from the attribute names defined in "BankI
 
 | Description | BankID attribute | Claim | Defined in | Comment | 
 | :--- | :--- | :--- | :--- | :--- |
-| Swedish Personal Number | `user.personalNumber` | `https://claims.oidc.se/`<br/>`1.0/personalNumber` | \[[OIDC.Sweden](#oidc-sweden)\] | |
+| Swedish Personal Number | `user.personalNumber` | `https://id.oidc.se/claim/`<br/>`personalIdentityNumber` | \[[OIDC.Sweden](#oidc-sweden)\] | |
 | Display (full) name | `user.name` | `name` | \[[OpenID.Core](#openid-core)\] | |
 | Given name | `user.givenName` | `given_name` | \[[OpenID.Core](#openid-core)\] | May be more than one name (separated by blank). |
 | Surname | `user.surname` | `family_name` | \[[OpenID.Core](#openid-core)\] | May be more than one name (separated by blank). |
-| Device IP-address | `device.ipAddress` | `https://claims.oidc.se/`<br />`1.0/deviceIp` | \[[OIDC.Sweden](#oidc-sweden)\] | |
-| Certificate notBefore time | `cert.notBefore` | `https://claims.oidc.se/`<br/>`1.0/credentialValidFrom` | \[[OIDC.Sweden](#oidc-sweden)\] | See also `https://claims.oidc.se/1.0/userSignature`. |
-| Certificate notAfter time | `cert.notAfter` | `https://claims.oidc.se/`<br/>`1.0/credentialValidTo` | \[[OIDC.Sweden](#oidc-sweden)\] | See also `https://claims.oidc.se/1.0/userSignature`. |
-| The BankID signature | `signature` | `https://claims.oidc.se/`<br/>`1.0/userSignature` | \[[OIDC.Sweden](#oidc-sweden)\] |  |
-| BankID OCSP response | `ocspResponse` | `https://claims.oidc.se/`<br />`1.0/authnEvidence` | \[[OIDC.Sweden](#oidc-sweden)\] | |
+| Device IP-address | `device.ipAddress` | `https://id.oidc.se/claim/`<br />`deviceIp` | \[[OIDC.Sweden](#oidc-sweden)\] | |
+| Certificate notBefore time | `cert.notBefore` | `https://id.oidc.se/claim/`<br/>`credentialValidFrom` | \[[OIDC.Sweden](#oidc-sweden)\] | See also `https://id.oidc.se/claim/userSignature`. |
+| Certificate notAfter time | `cert.notAfter` | `https://id.oidc.se/claim/`<br/>`credentialValidTo` | \[[OIDC.Sweden](#oidc-sweden)\] | See also `https://id.oidc.se/claim/userSignature`. |
+| The BankID signature | `signature` | `https://id.oidc.se/claim/`<br/>`userSignature` | \[[OIDC.Sweden](#oidc-sweden)\] |  |
+| BankID OCSP response | `ocspResponse` | `https://id.oidc.se/claim/`<br />`authnEvidence` | \[[OIDC.Sweden](#oidc-sweden)\] | |
 
 <a name="freja-eid"></a>
 ## 3. Freja eID
@@ -71,7 +71,7 @@ The following table defines a mapping from the attribute names defined in "Freja
 
 | Description | Freja eID attribute | Claim | Defined in | Comment | 
 | :--- | :--- | :--- | :--- | :--- |
-| Swedish Personal Number | `ssnuserinfo.ssn` | `https://claims.oidc.se/`<br/>`1.0/personalNumber` | \[[OIDC.Sweden](#oidc-sweden)\] | Freja's way of delivering SSN attribute included information about the country (`ssnuserinfo.country=SE`). |
+| Swedish Personal Number | `ssnuserinfo.ssn` | `https://id.oidc.se/claim/`<br/>`personalIdentityNumber`<br />or<br />`https://id.oidc.se/claim/`<br/>`coordinationNumber` | \[[OIDC.Sweden](#oidc-sweden)\] | Freja's way of delivering SSN attribute included information about the country (`ssnuserinfo.country=SE`). |
 | Given name | `basicUserInfo.name` | `given_name` | \[[OpenID.Core](#openid-core)\] | TODO: Does Freja's `basicUserInfo.name` mean given name of full name? |
 | Surname | `basicUserInfo.surname` | `family_name` | \[[OpenID.Core](#openid-core)\] | May be more than one name (separated by blank). |
 | E-mail address (primary) | `emailAddress` | `email` | \[[OpenID.Core](#openid-core)\] | See also `email_verified`. |

--- a/swedish-oidc-attribute-specification.md
+++ b/swedish-oidc-attribute-specification.md
@@ -2,7 +2,7 @@
 
 # Attribute Specification for the Swedish OpenID Connect Profile
 
-### Version: 1.0 - draft 02 - 2023-03-22
+### Version: 1.0 - draft 02 - 2023-04-03
 
 ## Abstract
 
@@ -81,9 +81,13 @@ These keywords are capitalized when used to unambiguously specify requirements o
 <a name="attributes-and-claims"></a>
 ## 2. Attributes and Claims
 
-This specification defines a set of claims that extend the set of standard claims defined in \[[RFC7515](#rfc7515)\] and section 5.1 of \[[OpenID.Core](#openid-core)\]. A full listing of standard claims can be found in the [IANA JSON Web Token Claims Registry](https://www.iana.org/assignments/jwt/jwt.xhtml#claims), \[[IANA-Reg](#iana-reg)\].
+This specification defines a set of claims that extend the set of standard claims defined in \[[RFC7515](#rfc7515)\] and 
+section 5.1 of \[[OpenID.Core](#openid-core)\]. A full listing of standard claims can be found in the [IANA JSON Web Token Claims
+Registry](https://www.iana.org/assignments/jwt/jwt.xhtml#claims), \[[IANA-Reg](#iana-reg)\].
 
-The claims defined in this specification are named in a collision-resistant manner, as described in JSON Web Token (JWT), \[[RFC7515](#rfc7515)\], specification. All claims defined within this specification are prefixed with the namespace `https://claims.oidc.se`.
+The claims and scopes defined in this specification are named in a collision-resistant manner, as described in JSON Web Token (JWT),
+\[[RFC7515](#rfc7515)\], specification. All claims and scopes defined within this specification are prefixed with the namespaces 
+`https://id.oidc.se/claim/` and `https://id.oidc.se/scope/` respectively.
 
 <a name="user-identity-claims"></a>
 ### 2.1. User Identity Claims
@@ -91,7 +95,7 @@ The claims defined in this specification are named in a collision-resistant mann
 <a name="swedish-personal-identity-number"></a>
 #### 2.1.1. Swedish Personal Identity Number
 
-**Claim:** `https://claims.oidc.se/1.0/personalIdentityNumber`
+**Claim:** `https://id.oidc.se/claim/personalIdentityNumber`
 
 **Description:** Swedish civic registration number (”personnummer”) according to \[[SKV704](#skv704)\].
 
@@ -100,7 +104,7 @@ The claims defined in this specification are named in a collision-resistant mann
 <a name="swedish-coordination-number"></a>
 #### 2.1.2. Swedish Coordination Number
 
-**Claim:** `https://claims.oidc.se/1.0/coordinationNumber`
+**Claim:** `https://id.oidc.se/claim/coordinationNumber`
 
 **Description:** Swedish coordination number (”samordningsnummer”) according to \[[SKV707](#skv707)\].
 
@@ -111,14 +115,14 @@ below for a claim definition that represents a coordination number level. This c
 the `coordinationNumber` claim.
 
 > **Note (ii):** A Swedish coordination number also has a "status" associated. This status can be active, on hold or
-> deregistered. This profile's definition of the `https://claims.oidc.se/1.0/coordinationNumber` claim does not
+> deregistered. This profile's definition of the `https://id.oidc.se/claim/coordinationNumber` claim does not
 > put any requirements regarding the number's status. However, this can be made when the claim is part of a scope,
 > see section [3.2](#natural-person-identity-personal-number), [Natural Person Identity - Personal Number](#natural-person-identity-personal-number) below.
 
 <a name="coordination-number-level"></a>
 ##### 2.1.2.1. Coordination Number Level
 
-**Claim:** `https://claims.oidc.se/1.0/coordinationNumberLevel`
+**Claim:** `https://id.oidc.se/claim/coordinationNumberLevel`
 
 **Description:** According to \[[2021/22:276](#2021-22-276)\] a Swedish coordination number is classified with a "level"
 that tells how well the holder has proven his or her identity in conjunction with the issuance of the number. Possible levels are:
@@ -144,7 +148,7 @@ alone implies that the consuming entity MUST ensure that status of the coordinat
 <a name="previous-coordination-number"></a>
 ##### 2.1.2.2. Previous Coordination Number
 
-**Claim:** `https://claims.oidc.se/1.0/previousCoordinationNumber`
+**Claim:** `https://id.oidc.se/claim/previousCoordinationNumber`
 
 **Description:**  All individuals born in Sweden or moving to Sweden with the intention of staying one year or longer will be
 assigned a personal identity number ("personnummer") and registered in the population register. Prior to being assigned a 
@@ -165,9 +169,9 @@ newly assigned identity number. The `previousCoordinationNumber` claim is typica
 
 **Type:** See [2.1.1](#swedish-personal-identity-number) and [2.1.2](#swedish-coordination-number) above.
 
-> **Note (i):** This claim is a special-purpose claim that most likely only will be used in very specific use cases. Therefore it is not
-included in any scope definitions below. A service provider wishing to potentially receive this claim SHOULD request is explicitly 
-using the `claims` request parameter.
+> **Note (i):** This claim is a special-purpose claim that most likely only will be used in very specific use cases. 
+Therefore it is not included in any scope definitions below. A service provider wishing to potentially receive this claim
+SHOULD request is explicitly using the `claims` request parameter.
 
 > **Note (ii):** This profile does not put any requirements regarding the "status" associated with the coordination number
 represented. Since it has been superseded by a Swedish personal identity number ("personnummer") its status may be non-active.
@@ -180,7 +184,7 @@ This section defines a number of claims in the area of organizational identities
 <a name="swedish-organization-number"></a>
 #### 2.2.1. Swedish Organization Number
 
-**Claim:** `https://claims.oidc.se/1.0/orgNumber`
+**Claim:** `https://id.oidc.se/claim/orgNumber`
 
 **Description:** Swedish organizational number ("organisationsnummer") according to \[[SKV709](#skv709)\].
 
@@ -189,10 +193,11 @@ This section defines a number of claims in the area of organizational identities
 <a name="swedish-organizational-affiliation"></a>
 #### 2.2.2. Swedish Organizational Affiliation
 
-**Claim:** `https://claims.oidc.se/1.0/orgAffiliation`
+**Claim:** `https://id.oidc.se/claim/orgAffiliation`
 
-**Description:** The personal identity at a Swedish organization (identified as a Swedish organizational number according to \[[SKV709](#skv709)\]). The `orgAffiliation` claim is intended to be used as a primary identity claim for global personal organizational 
-identities. It consists of a personal identifier and an organizational identifier code (`orgNumber`).
+**Description:** The personal identity at a Swedish organization (identified as a Swedish organizational number according to 
+\[[SKV709](#skv709)\]). The `orgAffiliation` claim is intended to be used as a primary identity claim for global personal
+organizational identities. It consists of a personal identifier and an organizational identifier code (`orgNumber`).
 
 This specification does not impose any specific requirements concerning the personal identifier part of the claim other than that
 it MUST be unique for the given organization.
@@ -210,7 +215,7 @@ may be the, but is not required to be, the "personal-id" part of the claim.
 <a name="organization-name"></a>
 #### 2.2.3. Organization Name
 
-**Claim:** `https://claims.oidc.se/1.0/orgName`
+**Claim:** `https://id.oidc.se/claim/orgName`
 
 **Description:** Registered organization name.
 
@@ -219,7 +224,7 @@ may be the, but is not required to be, the "personal-id" part of the claim.
 <a name="organizational-unit-name"></a>
 #### 2.2.4. Organizational Unit Name
 
-**Claim:** `https://claims.oidc.se/1.0/orgUnit`
+**Claim:** `https://id.oidc.se/claim/orgUnit`
 
 **Description:** Organizational unit name.
 
@@ -228,12 +233,14 @@ may be the, but is not required to be, the "personal-id" part of the claim.
 <a name="authentication-information-claims"></a>
 ### 2.3. Authentication Information Claims
 
-An "authentication information" claim delivers information about a specific authentication event. An identity provider SHOULD deliver these kinds of claims in an ID token and not from the UserInfo endpoint since the values the claims represent refers to an event, and not user properties as such. 
+An "authentication information" claim delivers information about a specific authentication event. An identity provider SHOULD
+deliver these kinds of claims in an ID token and not from the UserInfo endpoint since the values the claims represent refers
+to an event, and not user properties as such. 
 
 <a name="user-certificate"></a>
 #### 2.3.1. User Certificate
 
-**Claim:** `https://claims.oidc.se/1.0/userCertificate`
+**Claim:** `https://id.oidc.se/claim/userCertificate`
 
 **Description:** An X.509 certificate presented by the subject (user) during the authentication process.
 
@@ -242,7 +249,7 @@ An "authentication information" claim delivers information about a specific auth
 <a name="user-signature"></a>
 #### 2.3.2. User Signature
 
-**Claim:** `https://claims.oidc.se/1.0/userSignature`
+**Claim:** `https://id.oidc.se/claim/userSignature`
 
 **Description:** A signature that was produced by the subject (user) during the authentication, or signature, process.
 
@@ -258,7 +265,7 @@ A relying party may wish to get information about the user's credentials used du
 <a name="credential-valid-from"></a>
 ##### 2.3.3.1. Credential Valid From
 
-**Claim:** `https://claims.oidc.se/1.0/credentialValidFrom`
+**Claim:** `https://id.oidc.se/claim/credentialValidFrom`
 
 **Description:** The start time of the user credential's validity. 
 
@@ -267,7 +274,7 @@ A relying party may wish to get information about the user's credentials used du
 <a name="credential-valid-to"></a>
 ##### 2.3.3.2. Credential Valid To
 
-**Claim:** `https://claims.oidc.se/1.0/credentialValidTo`
+**Claim:** `https://id.oidc.se/claim/credentialValidTo`
 
 **Description:** The end time of the user credential's validity. 
 
@@ -276,7 +283,7 @@ A relying party may wish to get information about the user's credentials used du
 <a name="device-ip-address"></a>
 ##### 2.3.3.3. Device IP Address
 
-**Claim:** `https://claims.oidc.se/1.0/deviceIp`
+**Claim:** `https://id.oidc.se/claim/deviceIp`
 
 **Description:** If the user authenticated using an online device holding the user credentials (such as a mobile phone) this claim may be used to inform the relying party of the IP address of that device. 
 
@@ -287,9 +294,12 @@ A relying party may wish to get information about the user's credentials used du
 <a name="authentication-evidence"></a>
 ### 2.3.4. Authentication Evidence
 
-**Claim:** `https://claims.oidc.se/1.0/authnEvidence`
+**Claim:** `https://id.oidc.se/claim/authnEvidence`
 
-**Description:** A generic claim that can be issued by an identity provider to supply the relying party with proof, or evidence, about the authentication process. It may be especially interesting for some relying parties in the identity provider has delegated all, or parts, of the authentication process to another party. In such cases, the claim can hold the encoding of an OCSP response, a SAML assertion, or even a signed JWT.
+**Description:** A generic claim that can be issued by an OpenID Provider to supply the client with proof,
+or evidence, about the authentication process. It may be especially interesting for some clients if the
+provider has delegated all, or parts, of the authentication process to another party. In such cases, the
+claim can hold the encoding of an OCSP response, a SAML assertion, or even a signed JWT.
 
 > Note: This specification does not further specify the contents of the claim.  
 
@@ -303,36 +313,40 @@ This section contains definitions of general purpose claims that do not fit into
 <a name="country"></a>
 #### 2.4.1. Country
 
-**Claim:** `https://claims.oidc.se/1.0/country`
+**Claim:** `https://id.oidc.se/claim/country`
 
-**Description:** \[[OpenID.Core](#openid-core)\] defines the `address` claim containing a `country` field, but there are many other areas where a country needs to be represented other than in the context of an individual's address. The `https://claims.oidc.se/1.0/country` claim is a general purpose claim that can be used to represent a country.
+**Description:** \[[OpenID.Core](#openid-core)\] defines the `address` claim containing a `country` field, but
+there are many other areas where a country needs to be represented other than in the context of an individual's
+address. The `https://id.oidc.se/claim/country` claim is a general purpose claim that can be used to represent a country.
 
 **Type:** String. ISO 3166-1 alpha-2 \[[ISO3166](#iso3166)\] two letter country code.
 
 <a name="birth-name"></a>
 #### 2.4.2. Birth Name
 
-**Claim:** `https://claims.oidc.se/1.0/birthName`
+**Claim:** `https://id.oidc.se/claim/birthName`
 
-**Description:** Claims that corresponds to the `name` claim defined in \[[OpenID.Core](#openid-core)\] but is the full name at the time of birth for the subject.
+**Description:** Claims that corresponds to the `name` claim defined in \[[OpenID.Core](#openid-core)\] but is the
+full name at the time of birth for the subject.
 
 **Type:** String
 
 <a name="place-of-birth"></a>
 #### 2.4.3. Place of Birth
 
-**Claim:** `https://claims.oidc.se/1.0/placeOfbirth`
+**Claim:** `https://id.oidc.se/claim/placeOfbirth`
 
-**Description:** Claim representing the place of birth for the subject. This specification does not define "place". Depending on the context it may be "City" or "City, Country" or any other representation.
+**Description:** Claim representing the place of birth for the subject. This specification does not define "place".
+Depending on the context it may be "City" or "City, Country" or any other representation.
 
 **Type:** String 
 
 <a name="age"></a>
 #### 2.4.4. Age
 
-**Claim:** `https://claims.oidc.se/1.0/age`
+**Claim:** `https://id.oidc.se/claim/age`
 
-**Description:** Claim representing the age (in years) of the subject person. 
+**Description:** Claim representing the age (in years) of the subject person.
 
 **Type:** Integer
 
@@ -351,40 +365,51 @@ This section defines a set of scopes where each named scope maps to a set of cla
 Section 5.4 of \[[OpenID.Core](#openid-core)\] defines a set of standard scope values including the `profile` scope that
 maps to the end-user "profile". This information comprises of the claims: `name`, `family_name`, `given_name`, `middle_name`, `nickname`, `preferred_username`, `profile`, `picture`, `website`, `gender`, `birthdate`, `zoneinfo`, `locale`, and `updated_at`.
 
-The `profile` scope is pretty much intended as a scope for an Internet user wishing to create an account on a website. Claims such as `preferred_username`, `picture` and `website` indicates that. Of course, not all claims within the scope need to be delivered, but it is more useful to define more fine grained scopes. Also, for the sake of privacy a relying party should not ask for more claims than it actually requires. Therefore, this specification defines a set of scopes that combines standard claims with the claims defined in this specification.
+The `profile` scope is pretty much intended as a scope for an Internet user wishing to create an account on a website. Claims 
+such as `preferred_username`, `picture` and `website` indicates that. Of course, not all claims within the scope need to be
+delivered, but it is more useful to define more fine grained scopes. Also, for the sake of privacy a relying party should not
+ask for more claims than it actually requires. Therefore, this specification defines a set of scopes that combines standard 
+claims with the claims defined in this specification.
 
-This specification specifically takes into consideration the Swedish eID solutions, and the attributes that are tied to a Swedish eID.
+This specification specifically takes into consideration the Swedish eID solutions, and the attributes that are tied to a 
+Swedish eID.
 
-For each scope defined below a set of claims is declared. Each declared claim has an indicator telling whether it is Mandatory or Optional within the given scope. A profile specification extending this attribute specification MAY change a declared claim's requirement from Optional to Mandatory, but MUST NOT lower the requirements from Mandatory to Optional. In those cases the extending specification need to define a new scope. Also, a profile specification extending this attribute MAY declare new claims, but MUST NOT remove any claims from the scope definition.
+For each scope defined below a set of claims is declared. Each declared claim has an indicator telling whether it is 
+Mandatory or Optional within the given scope. A profile specification extending this attribute specification MAY change 
+a declared claim's requirement from Optional to Mandatory, but MUST NOT lower the requirements from Mandatory to Optional.
+In those cases the extending specification need to define a new scope. Also, a profile specification extending this
+attribute MAY declare new claims, but MUST NOT remove any claims from the scope definition.
 
 <a name="natural-person-name-information"></a>
 ### 3.1. Natural Person Name Information
 
-**Scope:** `https://scopes.oidc.se/1.0/naturalPersonName`
+**Scope:** `https://id.oidc.se/scope/naturalPersonName`
 
-**Description:** A scope that defines a claim set that provides basic natural person information without revealing the civic registration number of the subject.
+**Description:** A scope that defines a claim set that provides basic natural person information without revealing the
+civic registration number of the subject.
 
-| Claim | Description/comment | Requirement |
-| :--- | :--- | :--- |
-| `family_name` | Surname/family name - \[[OpenID.Core](#openid-core)\]. | Mandatory |
-| `given_name` | Given name - \[[OpenID.Core](#openid-core)\]. | Mandatory |
-| `name` | Display name - \[[OpenID.Core](#openid-core)\]. | Mandatory |
+| Claim | Description/comment | Reference | Requirement |
+| :--- | :--- | :--- | :--- |
+| `family_name` | Surname/family name | \[[OpenID.Core](#openid-core)\] | Mandatory |
+| `given_name` | Given name | \[[OpenID.Core](#openid-core)\] | Mandatory |
+| `name` | Display name | \[[OpenID.Core](#openid-core)\] | Mandatory |
 
 <a name="natural-person-identity-personal-number"></a>
 ### 3.2. Natural Person Identity - Personal Number
 
-**Scope:** `https://scopes.oidc.se/1.0/naturalPersonNumber`
+**Scope:** `https://id.oidc.se/scope/naturalPersonNumber`
 
-**Description:** The scope extends the `https://scopes.oidc.se/1.0/naturalPersonName` scope with a Swedish civic registration number (personnummer) or a Swedish coordination number (samordningsnummer).
+**Description:** The scope extends the `https://id.oidc.se/scope/naturalPersonName` scope with a Swedish civic
+registration number (personnummer) or a Swedish coordination number (samordningsnummer).
 
-| Claim | Description/comment | Requirement |
-| :--- | :--- | :--- |
-| `https://claims.oidc.se/1.0/`<br />`personalIdentityNumber` | Swedish civic registration number. | Mandatory<sup>\1</sup> |
-| `https://claims.oidc.se/1.0/`<br />`coordinationNumber` | Swedish coordination number. If delivered according to this scope, the coordination number SHOULD have a status of Active<sup>2</sup>. | Mandatory<sup>\1</sup> |
-| `family_name` | Surname/family name - \[[OpenID.Core](#openid-core)\]. | Mandatory |
-| `given_name` | Given name - \[[OpenID.Core](#openid-core)\]. | Mandatory |
-| `name` | Display name - \[[OpenID.Core](#openid-core)\]. | Mandatory | 
-| `birthdate` | Date of birth - \[[OpenID.Core](#openid-core)\]. | Optional | 
+| Claim | Description/comment | Reference | Requirement |
+| :--- | :--- | :--- | :--- |
+| `https://id.oidc.se/claim/`<br />`personalIdentityNumber` | Swedish civic registration number. | This profile | Mandatory<sup>1</sup> |
+| `https://id.oidc.se/claim/`<br />`coordinationNumber` | Swedish coordination number. If delivered according to this scope, the coordination number SHOULD have a status of Active<sup>2</sup>. | This profile | Mandatory<sup>1</sup> |
+| `family_name` | Surname/family name | \[[OpenID.Core](#openid-core)\] | Mandatory |
+| `given_name` | Given name | \[[OpenID.Core](#openid-core)\] | Mandatory |
+| `name` | Display name | \[[OpenID.Core](#openid-core)\] | Mandatory | 
+| `birthdate` | Date of birth | \[[OpenID.Core](#openid-core)\] | Optional | 
 
 > **\[1\]**: A `personalIdentityNumber` OR `coordinationNumber` claim MUST be delivered, but not both.
 
@@ -397,35 +422,41 @@ For each scope defined below a set of claims is declared. Each declared claim ha
 <a name="natural-person-organizational-identity"></a>
 ### 3.3. Natural Person Organizational Identity
 
-**Scope:** `https://scopes.oidc.se/1.0/naturalPersonOrgId`
+**Scope:** `https://id.oidc.se/scope/naturalPersonOrgId`
 
-**Description:** The “Natural Person Organizational Identity” scope provides basic organizational identity information about a person. The organizational identity does not necessarily imply that the subject has any particular relationship with or standing within the organization, but rather that this identity has been issued/provided by that organization for any particular reason (employee, customer, consultant, etc.).
+**Description:** The “Natural Person Organizational Identity” scope provides basic organizational identity information about a
+person. The organizational identity does not necessarily imply that the subject has any particular relationship with or standing
+within the organization, but rather that this identity has been issued/provided by that organization for any particular reason
+(employee, customer, consultant, etc.).
 
-| Claim | Description/comment | Requirement |
-| :--- | :--- | :--- |
-| `name` | Display name. The claim MAY contain personal information such as the given name or surname, but it MAY also be used as an anonymized display name, for example, "Administrator 123". This is decided by the issuing organization (\[[OpenID.Core](#openid-core)\]). | Mandatory |
-| `https://claims.oidc.se/`<br />`1.0/orgAffiliation` | Personal identifier and organizational number. | Mandatory |
-| `https://claims.oidc.se/`<br />`1.0/orgName` | Organization name. | Mandatory |
-| `https://claims.oidc.se/`<br />`1.0/orgNumber` | Swedish organization number. This number can always be derived from the mandatory orgAffiliation claim, but for simplicity it is recommended that an attribute provider includes this claim. | Optional, but recommended | 
+| Claim | Description/comment | Reference | Requirement |
+| :--- | :--- | :--- | :--- |
+| `name` | Display name. The claim MAY contain personal information such as the given name or surname, but it MAY also be used as an anonymized display name, for example, "Administrator 123". This is decided by the issuing organization. | \[[OpenID.Core](#openid-core)\] | Mandatory |
+| `https://id.oidc.se/claim/`<br />`orgAffiliation` | Personal identifier and organizational number. | This profile | Mandatory |
+| `https://id.oidc.se/claim/`<br />`orgName` | Organization name. | This profile | Mandatory |
+| `https://id.oidc.se/claim/`<br />`orgNumber` | Swedish organization number. This number can always be derived from the mandatory orgAffiliation claim, but for simplicity it is recommended that an attribute provider includes this claim. | This profile | Optional, but recommended | 
 
 <a name="authentication-information"></a>
 ### 3.4. Authentication Information
 
-**Scope:** `https://scopes.oidc.se/1.0/authnInfo`
+**Scope:** `https://id.oidc.se/scope/authnInfo`
 
-**Description:** A scope that is used to request claims that represents information from the authentication process and information about the subject's credentials used to authenticate. 
+**Description:** A scope that is used to request claims that represents information from the authentication process and
+information about the subject's credentials used to authenticate. 
 
-This specification declares all claims as optional. A profile specification extending this attribute specification MAY change requirements to Mandatory and declare additional claims.
+This specification declares all claims as optional except for the `auth_time` claim. A profile specification extending
+this attribute specification MAY change requirements to Mandatory and declare additional claims.
 
-| Claim | Description/comment | Requirement |
-| :--- | :--- | :--- |
-| `txn` | Transaction identifier for the operation. See \[[RFC8417](#rfc8417)\]. | Optional |
-| `https://claims.oidc.se/`<br />`1.0/userCertificate` | The certificate presented by the user during the authentication process. | Optional |
-| `https://claims.oidc.se/`<br />`1.0/credentialValidFrom` | The start time of the user credential's validity. | Optional |
-| `https://claims.oidc.se/`<br />`1.0/credentialValidTo` | The end time of the user credential's validity. | Optional |
-| `https://claims.oidc.se/`<br />`1.0/deviceIp` | IP address of user's device holding the credentials. | Optional | 
+| Claim | Description/comment | Reference | Requirement |
+| :--- | :--- | :--- | :--- |
+| `auth_time` | Time when the end-user authentication occurred. | \[[OpenID.Core](#openid-core)\] | Mandatory |
+| `txn` | Transaction identifier for the operation. | \[[RFC8417](#rfc8417)\] | Optional |
+| `https://id.oidc.se/claim/`<br />`userCertificate` | The certificate presented by the user during the authentication process. | This profile | Optional |
+| `https://id.oidc.se/claim/`<br />`credentialValidFrom` | The start time of the user credential's validity. | This profile | Optional |
+| `https://id.oidc.se/claim/`<br />`credentialValidTo` | The end time of the user credential's validity. | This profile | Optional |
+| `https://id.oidc.se/claim/`<br />`deviceIp` | IP address of user's device holding the credentials. | This profile | Optional | 
 
-Note: The `https://claims.oidc.se/1.0/authnEvidence` (authentication evidence) claim is not declared in the scope and need to be requested explicitly if required. The reason for this is that few relying parties are likely to be interested in that kind of detailed authentication information.
+Note: The `https://id.oidc.se/claim/authnEvidence` (authentication evidence) claim is not declared in the scope and need to be requested explicitly if required. The reason for this is that few relying parties are likely to be interested in that kind of detailed authentication information.
 
 <a name="normative-references"></a>
 ## 4. Normative References

--- a/swedish-oidc-profile.md
+++ b/swedish-oidc-profile.md
@@ -2,7 +2,7 @@
 
 # The Swedish OpenID Connect Profile
 
-### Version: 1.0 - draft 02 - 2023-03-30
+### Version: 1.0 - draft 02 - 2023-04-03
 
 ## Abstract
 
@@ -140,7 +140,7 @@ Below follows a table with request parameters that are mandatory according to th
 | `request` | Request Object JWT. See [2.1.7](#request-objects-request-and-request-uri-parameters). | Optional for RP<br />Mandatory for OP |
 | `request_uri` | Request Object JWT passed by reference. See [2.1.7](#request-objects-request-and-request-uri-parameters). | Optional |
 | `code_challenge`, `code_challenge_method` | Proof Key for Code Exchange (PKCE). See [2.1.8](#pkce-parameters) below. | Optional |
-| `https://claims.oidc.se/`<br />`1.0/userMessage` | Client provided user message. See [2.3.1](#client-provided-user-message) below. | Optional |
+| `https://id.oidc.se/`<br />`param/userMessage` | Client provided user message. See [2.3.1](#client-provided-user-message) below. | Optional |
 
 
 <a name="the-scope-parameter"></a>
@@ -372,20 +372,24 @@ Relying Parties MUST follow the requirements in section [3.1.3.7] of \[[OpenID.C
 <a name="claims-and-scopes"></a>
 ## 4. Claims and Scopes
 
-The "Attribute Specification for the Swedish OpenID Connect Profile" document, \[[AttrSpec](#attr-spec)\], defines claims and scopes to be used within the Swedish OpenID Connect profile. This specification defines claims and scopes for many different use cases, and some definitions may not be applicable for all entities. Therefore, sections [4.1](#mandatory-identity-claims) and [4.2](#mandatory-identity-scopes) lists the claims and scopes that MUST be supported by Relying Parties and OpenID Providers that are compliant with this profile. 
+The "Attribute Specification for the Swedish OpenID Connect Profile" document, \[[AttrSpec](#attr-spec)\], defines claims and
+scopes to be used within the Swedish OpenID Connect profile. This specification defines claims and scopes for many different
+use cases, and some definitions may not be applicable for all entities. Therefore, sections [4.1](#mandatory-identity-claims)
+and [4.2](#mandatory-identity-scopes) lists the claims and scopes that MUST be supported by Relying Parties and OpenID Providers
+that are compliant with this profile. 
 
 <a name="mandatory-identity-claims"></a>
 ### 4.1. Mandatory Identity Claims
 
 | Claim | Description | Reference |
 | :--- | :--- | :--- |
-| `https://claims.oidc.se/`<br />`1.0/personalNumber` | Swedish Personal Identity Number. | \[[AttrSpec](#attr-spec)\] |
+| `https://id.oidc.se/claim/`<br />`personalIdentityNumber` | Swedish Personal Identity Number. | \[[AttrSpec](#attr-spec)\] |
 | `family_name` | Family name. | \[[OpenID.Core](#openid-core)\] |
 | `given_name` | Given name<sup>1</sup>. | \[[OpenID.Core](#openid-core)\] |
 | `name` | Display name/full name. | \[[OpenID.Core](#openid-core)\] |
 | `txn` | Transaction identifier. | \[[RFC8417](#rfc8417)\] |
 
-**Note:** If an OpenID Provider has the ability to deliver the `birthdate` claim, defined in \[[OpenID.Core](#openid-core)\], it MUST support the `https://claims.oidc.se/1.0/age` claim (as defined in \[[AttrSpec](#attr-spec)\]).
+**Note:** If an OpenID Provider has the ability to deliver the `birthdate` claim, defined in \[[OpenID.Core](#openid-core)\], it MUST support the `https://id.oidc.se/claim/age` claim (as defined in \[[AttrSpec](#attr-spec)\]).
 
 > \[1\]: In the rare cases when a person's record in the population register does not include a given name, and `given_name` is requested, directly or indirectly via a scope, the value `-` SHOULD be assigned to the `given_name` claim.
 
@@ -394,8 +398,8 @@ The "Attribute Specification for the Swedish OpenID Connect Profile" document, \
 
 | Scope | Description | Reference |
 | :--- | :--- | :--- |
-| `https://scopes.oidc.se/`<br />`1.0/naturalPersonName` | Natural Person Name Information. | \[[AttrSpec](#attr-spec)\] |
-| `https://scopes.oidc.se/`<br />`1.0/naturalPersonPnr` | Natural Person Identity - Personal Number. | \[[AttrSpec](#attr-spec)\] |
+| `https://id.oidc.se/scope/`<br />`naturalPersonName` | Natural Person Name Information. | \[[AttrSpec](#attr-spec)\] |
+| `https://id.oidc.se/scope/`<br />`naturalPersonNumber` | Natural Person Identity - Personal Number. | \[[AttrSpec](#attr-spec)\] |
 | `profile` | OIDC default profile claims<sup>1</sup>. | \[[OpenID.Core](#openid-core)\] |
 
 > \[1\]: At least `family_name`, `given_name` and `name` MUST be supported.
@@ -424,7 +428,10 @@ Section 5.4 of \[[OpenID.Core](#openid-core)\] states:
 
 The Swedish OpenID Connect profile takes another approach regarding the primary user identity, and the primary user identity is most often represented by a claim delivered as part of a requested scope. Therefore, this profile, requires that if any of the scopes defined in section 3 of \[[AttrSpec](#attr-spec)\] are requested the corresponding claims MUST be delivered in the ID token<sup>3</sup>.
 
-Note: In order to be compliant with \[[OpenID.Core](#openid-core)\] it is RECOMMENDED that claims requested by the scope values `profile`, `email`, `address`, and `phone` are delivered from the UserInfo endpoint. However, there are some overlap between the `profile` scope and the  `https://scopes.oidc.se/1.0/naturalPersonName` and `https://scopes.oidc.se/1.0/naturalPersonPnr` scopes, and a Relying Party SHOULD use the latter scopes instead of the `profile` scope where applicable. 
+Note: In order to be compliant with \[[OpenID.Core](#openid-core)\] it is RECOMMENDED that claims requested by the scope values
+`profile`, `email`, `address`, and `phone` are delivered from the UserInfo endpoint. However, there are some overlap between the
+`profile` scope and the  `https://id.oidc.se/scope/naturalPersonName` and `https://id.oidc.se/scope/naturalPersonNumber` scopes,
+and a Relying Party SHOULD use the latter scopes instead of the `profile` scope where applicable. 
 
 > \[1\]: Apart from the mandatory `sub` claim that also can be seen as an identity attribute.
 


### PR DESCRIPTION
Changed prefix to `https://id.oidc.se/<type>/`.

Closes #35 