### PR TITLE
IS-38 Section about error responses

### DIFF
--- a/swedish-oidc-profile.md
+++ b/swedish-oidc-profile.md
@@ -2,7 +2,7 @@
 
 # The Swedish OpenID Connect Profile
 
-### Version: 1.0 - draft 02 - 2023-04-03
+### Version: 1.0 - draft 02 - 2023-04-13
 
 ## Abstract
 
@@ -16,7 +16,7 @@ This specification defines a profile for OpenID Connect for use within the Swedi
     
     1.2. [Conformance](#conformance)    
 
-2. [**Authentication Requests**](#authentication-requests)
+2. [**Authentication Requests and Responses**](#authentication-requests-and-responses)
 
     2.1. [Authentication Request Parameters](#authentication-request-parameters)   
 
@@ -41,6 +41,8 @@ This specification defines a profile for OpenID Connect for use within the Swedi
     2.3.1. [Client Provided User Message](#client-provided-user-message)
 	
     2.3. [Processing of Authentication Requests](#processing-of-authentication-requests)
+    
+    2.4. [Authentication Responses](#authentication-responses)
 	
 3. [**Token Endpoint Requests and ID Token Issuance**](#token-endpoint-requests-and-id-token-issuance)
     
@@ -108,8 +110,8 @@ This profile defines requirements for OpenID Connect Relying Parties (clients) a
 
 When a component compliant with this profile is interacting with other components compliant with this profile, all components MUST fully conform to the features and requirements of this specification. Any interaction with components that are not compliant with this profile is out of scope for this specification.
 
-<a name="authentication-requests"></a>
-## 2. Authentication Requests
+<a name="authentication-requests-and-responses"></a>
+## 2. Authentication Requests and Responses
 
 An OpenID Connect authentication request is a request sent to the Authorization endpoint of an OpenID Provider. These requests MUST be sent using the authorization code flow.
 
@@ -276,16 +278,44 @@ the `https://id.oidc.se/param/userMessage` member.
 ...
 ```
 
-
-
 <a name="processing-of-authentication-requests"></a>
 ### 2.3. Processing of Authentication Requests
 
 An OpenID Provider compliant with this profile MUST follow the requirements stated in section 3.1.2.2 of \[[OpenID.Core](#openid-core)\].
 
-Furthermore, the OpenID Provider MUST not proceed with the authentication if the request contains the `acr_values` request parameter and none of the specified Requested Authentication Context Class Reference values can be used to authenticate the end-user. In these cases the provider MUST respond with an `invalid_request`<sup>1</sup> error.
+Furthermore, the OpenID Provider MUST not proceed with the authentication if the request contains the `acr_values` request parameter and none of the specified Requested Authentication Context Class Reference values can be used to authenticate the end-user. In these cases the provider SHOULD respond with an `unmet_authentication_requirements` error as defined in \[[OpenID.Unmet-AuthnReq](#openid-unmet-authnreq)\].
 
-> \[1\]: It does not exist a specific OAuth2 or OpenID Connect error code that indicates an ACR error. Therefore, it is RECOMMENDED that the error response `error_description` includes text that informs the caller about the specific error.
+<a name="authentication-responses"></a>
+### 2.4. Authentication Responses
+
+Entities compliant with this profile MUST follow the requirements regarding authentication error
+responses put in section 3.1.2.6 of \[[OpenID.Core](#openid-core)\].
+
+OpenID Providers SHOULD limit the use of error codes to the sets defined in:
+
+- Section 4.1.2.1 of \[[OAuth2.RFC6749](#oauth2-rfc6749)\],
+
+- section 3.1.2.6 of \[[OpenID.Core](#openid-core)\], and, 
+
+- \[[OpenID.Unmet-AuthnReq](#openid-unmet-authnreq)\].
+
+The OpenID Connect and OAuth2 specifications do not specify any detailed error codes describing
+different types of authentication failures. Therefore, it is the OpenID Provider's responsibility
+to inform the user in detail about why a particular authentication failed. The Relying Party normally
+only receives an `access_denied` error code.
+
+One special case that is not handled by OpenID Connect (or SAML) is when an end user cancels an operation
+at the OP. This is shortcoming, since from the Relying Party's UX point of view this should often not be
+seen as an error. Normally, the user should just be passed back to the application's login page. 
+A typical reason for cancelling a login attempt would be that the user selected the wrong login method
+(OP), and needs to get back to the application login page.
+
+Therefore, OpenID Providers compliant with this specification SHOULD handle cancelled authentications
+according to the following:
+
+No error view is displayed for the user at the OP. Instead an authentication error response is sent 
+back to the Relying Party where the `error` parameter is set to `access_denied` and the `error_description`
+parameter begins with the text `"user-cancel"`.
 
 <a name="token-endpoint-requests-and-id-token-issuance"></a>
 ## 3. Token Endpoint Requests and ID Token Issuance
@@ -575,6 +605,10 @@ An entity processing a message in which an algorithm not listed below has been u
 <a name="openid-core"></a>
 **\[OpenID.Core\]**
 > [Sakimura, N., Bradley, J., Jones, M., de Medeiros, B. and C. Mortimore, "OpenID Connect Core 1.0", August 2015](https://openid.net/specs/openid-connect-core-1_0.html).
+
+<a name="openid-unmet-authnreq"></a>
+**\[OpenID.Unmet-AuthnReq\]**
+> [T. Lodderstedt, "OpenID Connect Core Error Code unmet\_authentication\_requirements"](OpenID Connect Core Error Code unmet_authentication_requirements).
 
 <a name="openid-discovery"></a>
 **\[OpenID.Discovery\]**

--- a/swedish-oidc-profile.md
+++ b/swedish-oidc-profile.md
@@ -608,7 +608,7 @@ An entity processing a message in which an algorithm not listed below has been u
 
 <a name="openid-unmet-authnreq"></a>
 **\[OpenID.Unmet-AuthnReq\]**
-> [T. Lodderstedt, "OpenID Connect Core Error Code unmet\_authentication\_requirements"](OpenID Connect Core Error Code unmet_authentication_requirements).
+> [T. Lodderstedt, "OpenID Connect Core Error Code unmet\_authentication\_requirements"](https://openid.net/specs/openid-connect-unmet-authentication-requirements-1_0.html).
 
 <a name="openid-discovery"></a>
 **\[OpenID.Discovery\]**

--- a/swedish-oidc-profile.md
+++ b/swedish-oidc-profile.md
@@ -305,7 +305,7 @@ to inform the user in detail about why a particular authentication failed. The R
 only receives an `access_denied` error code.
 
 One special case that is not handled by OpenID Connect (or SAML) is when an end user cancels an operation
-at the OP. This is shortcoming, since from the Relying Party's UX point of view this should often not be
+at the OP. This is a shortcoming, since from the Relying Party's UX point of view this should often not be
 seen as an error. Normally, the user should just be passed back to the application's login page. 
 A typical reason for cancelling a login attempt would be that the user selected the wrong login method
 (OP), and needs to get back to the application login page.


### PR DESCRIPTION
Added section about authentication error responses, and wrote about how the profile wants OP:s to handle cancelled authentications.