### PR TITLE
IS-3 Example of claims parameter

### DIFF
--- a/swedish-oidc-profile.md
+++ b/swedish-oidc-profile.md
@@ -178,7 +178,7 @@ By setting the `prompt` parameter to `login` the Relying Party instructs the Ope
 An OpenID Provider MUST support the `prompt` parameter according to the requirements in section 3.1.2.1 of \[[OpenID.Core](#openid-core)\], with the following extension: If the value of the `prompt` parameter contains the "login" string value the OpenID Provider MUST prompt the end-user for (re-)authentication.
 
 <a name="the-login-hint-parameter"></a>
-#### 2.1.5. The login_hint Parameter
+#### 2.1.5. The login\_hint Parameter
 
 Section 3.1.2.1 of \[[OpenID.Core](#openid-core)\] states that a Relying Party MAY include the `login_hint` parameter in an authentication request, and that its value is an identifier of the end-user. 
 
@@ -192,6 +192,27 @@ It is RECOMMENDED that a Relying Party uses the `claims` request parameter in fa
 Section 5.5 of \[[OpenID.Core](#openid-core)\] specifies how individual claims can be requested using the `claims` request parameter.
 
 An OpenID Provider compliant with this profile MUST support the `claims` parameter, both when passed as an OAuth parameter and when included in a Request Object (see [2.1.7](#request-objects-request-and-request-uri-parameters)).
+
+Section [2.1.5](#the-login-hint-parameter) recommends that the `claims` parameter is used
+in favour on the `login_hint` parameter. 
+
+The example below illustrates a value to the `claims` parameter where the Relying Party specifies 
+a value for a specific claim. By doing this instead of specifying the value as a `login_hint`, the
+RP gives the OpenID Provider a more exact view of the user being authenticated.
+
+```
+{
+  "id_token" : {
+    "https://id.oidc.se/claim/personalIdentityNumber" : { 
+      "essential" : true, 
+      "value" : "191212121212" 
+    }
+  }
+}
+```
+
+> By setting the `essential` parameter to `false`, or leaving it out, the RP can signal the
+value of a claim that necessarily wont be released.
 
 <a name="request-objects-request-and-request-uri-parameters"></a>
 #### 2.1.7. Request Objects (request and request_uri parameters)

--- a/swedish-oidc-profile.md
+++ b/swedish-oidc-profile.md
@@ -194,7 +194,7 @@ Section 5.5 of \[[OpenID.Core](#openid-core)\] specifies how individual claims c
 An OpenID Provider compliant with this profile MUST support the `claims` parameter, both when passed as an OAuth parameter and when included in a Request Object (see [2.1.7](#request-objects-request-and-request-uri-parameters)).
 
 Section [2.1.5](#the-login-hint-parameter) recommends that the `claims` parameter is used
-in favour on the `login_hint` parameter. 
+in favour of the `login_hint` parameter. 
 
 The example below illustrates a value to the `claims` parameter where the Relying Party specifies 
 a value for a specific claim. By doing this instead of specifying the value as a `login_hint`, the
@@ -212,7 +212,7 @@ RP gives the OpenID Provider a more exact view of the user being authenticated.
 ```
 
 > By setting the `essential` parameter to `false`, or leaving it out, the RP can signal the
-value of a claim that necessarily wont be released.
+value of a claim that necessarily will not be released.
 
 <a name="request-objects-request-and-request-uri-parameters"></a>
 #### 2.1.7. Request Objects (request and request_uri parameters)


### PR DESCRIPTION
Clarifications on how to signal information about a known identity from the RP to the OP. The `login_hint` is to generic, so the profile recommends using the `claims` parameter.

Closes #3 