### PR TITLE
IS-54 Moved request parameter extensions to separate document

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ The oidc-sweden/specifications repository is where the Working Group for the Swe
 
 * [Signature Extension for OpenID Connect 1.0 - draft](oidc-signature-extension.md) - A signature extension for OpenID Connect.
 
+* [Authentication Request Parameter Extensions for the Swedish OpenID Connect Profile 1.0 - draft](request-parameter-extensions.md) - Authentication request parameter extensions for the Swedish
+OpenID Connect Profile.
+
 
 
 

--- a/oidc-signature-extension.md
+++ b/oidc-signature-extension.md
@@ -2,7 +2,7 @@
 
 # Signature Extension for OpenID Connect
 
-### Version: 1.0 - draft 02 - 2023-04-05
+### Version: 1.0 - draft 02 - 2023-04-27
 
 ## Abstract
 
@@ -116,15 +116,20 @@ use case defined in this specification.
 
 **Parameter:** `https://id.oidc.se/param/signRequest`
 
-**Description:** The signature request parameter is included in an authentication request by the Relying Party in order
-to request a user signature. The signature request parameter contains input for this signature operation.
+**Description:** The signature request parameter is included in an authentication request by the 
+Relying Party in order to request a user signature. The signature request parameter contains input
+for this signature operation.
 
-**Value type:** The value for the signature request parameter claim is a JSON object<sup>1</sup> with the following fields:
+**Value type:** The value for the signature request parameter claim is a JSON object<sup>1</sup> 
+with the following fields:
 
-- `tbs_data` - The data to be signed as a Base64-encoded string. This specification does not specify the format on the supplied data. It is regulated by the signature scheme being used. This field is mandatory.
+- `tbs_data` - The data to be signed as a Base64-encoded string. This specification does not specify the
+format on the supplied data. It is regulated by the signature scheme being used. This field is mandatory.
 
-- `sign_message` - A sign message is the human readable text snippet that is displayed to the user as part of the signature process<sup>2</sup>. The `sign_message` field is a JSON object according to the `https://id.oidc.se/param/userMessage` request
-parameter as defined in section 2.2.1 of \[[OIDC.Sweden.Profile](#oidc-profile)\]. This field is mandatory.
+- `sign_message` - A sign message is the human readable text snippet that is displayed to the user as
+part of the signature process<sup>2</sup>. The `sign_message` field is a JSON object according to the
+`https://id.oidc.se/param/userMessage` request parameter as defined in section 2.1 of 
+\[[OIDC.Sweden.Param](#request-ext)\]. This field is mandatory.
 
 **Example:**
 
@@ -367,7 +372,7 @@ not be mixed.
 > **\[1\]:** See section 4.1.2.1 of \[[RFC6749](#rfc6749)\].
 
 > **\[2\]:** An OpenID Provider compliant with this specification MUST also be compliant with 
-\[[OIDC.Sweden.Profile](#oidc-profile)\], and \[[OIDC.Sweden.Profile](#oidc-profile)\] requires OpenID Providers to 
+\[[OIDC.Sweden.Profile](#oidc-profile)\], and that profile requires OpenID Providers to 
 support the `claims` request parameter.
 
 > **\[3\]:** For example an unsupported MIME type was specified.
@@ -381,7 +386,7 @@ claim, MUST be delivered in the ID Token and never from the UserInfo endpoint.
 <a name="discovery"></a>
 ### 5.3. Discovery
 
-OpenID Providers that supports the OpenID Connect Discovery standard, \[[OpenID.Discovery](#openid-discovery)\] and are compliant with this specification<sup>1</sup>, MUST meet the following requirements:
+OpenID Providers that are compliant with this specification<sup>1</sup>, MUST meet the following requirements discovery requirements:
 
 The `scopes_supported` MUST be present in the provider's discovery document and it MUST contain the scope 
 `https://id.oidc.se/scope/sign`.
@@ -400,17 +405,17 @@ has support for handling signature requests sent by reference as Request Objects
 As already stated in section 5.2 of \[[OIDC.Sweden.Profile](#oidc-profile)\], the `claims_parameter_supported` SHOULD be present
 and set to `true`.
 
-Support of sign messages during a signature operation is REQUIRED by this specification. It is RECOMMENDED that
-the OpenID Provider also supports displaying of "client provided user messages", as defined in section 2.2.1
-of \[[OIDC.Sweden.Profile](#oidc-profile)\]. This capability is declared using the discovery parameter
-`https://id.oidc.se/disco/userMessageSupported` (see section 5.3.1 of \[[OIDC.Sweden.Profile](#oidc-profile)\]).
-This effectively means that the OP supports displaying of user messages also when the user authenticates 
-(as opposed to signs).
+Support of sign messages during a signature operation is REQUIRED by this specification. It is 
+RECOMMENDED that the OpenID Provider also supports displaying of "client provided user messages", 
+as defined in section 2.1 of \[[OIDC.Sweden.Param](#request-ext)\]. This capability is declared 
+using the discovery parameter `https://id.oidc.se/disco/userMessageSupported` (see section 3.1.1 of 
+\[[OIDC.Sweden.Param](#request-ext)\]). This effectively means that the OP supports displaying of
+user messages also when the user authenticates (as opposed to signs).
 
-The `https://id.oidc.se/disco/userMessageSupportedMimeTypes` field, defined in section 5.3.1 of 
-\[[OIDC.Sweden.Profile](#oidc-profile)\], SHOULD be used to declare which MIME types that are supported regarding the 
-`sign_message` field of the `https://id.oidc.se/param/signRequest` parameter value. If not declared, `[ "text/plain" ]` 
-MUST be assumed.
+The `https://id.oidc.se/disco/userMessageSupportedMimeTypes` field, defined in section 3.1.2 of 
+\[[OIDC.Sweden.Param](#request-ext)\], SHOULD be used to declare which MIME types that are supported
+regarding the `sign_message` field of the `https://id.oidc.se/param/signRequest` parameter value.
+If not declared, `[ "text/plain" ]` MUST be assumed.
 
 > **\[1\]:** An OpenID Provider compliant with this specification MUST also be compliant with 
 \[[OIDC.Sweden.Profile](#oidc-profile)\] and thus meet the requirements stated in section 5.2 of that profile.
@@ -438,12 +443,17 @@ MUST be assumed.
 **\[RFC7515\]**
 > [Jones, M., Bradley, J., and N. Sakimura, “JSON Web Token (JWT)”, May 2015](https://tools.ietf.org/html/rfc7515).
 
+<a name="oidc-profile"></a>
+**\[OIDC.Sweden.Profile\]**
+> [The Swedish OpenID Connect Profile](https://github.com/oidc-sweden/specifications/blob/main/swedish-oidc-profile.md).
+
+<a name="request-ext"></a>
+**\[OIDC.Sweden.Params\]**
+> [Authentication Request Parameter Extensions for the Swedish OpenID Connect Profile](https://github.com/oidc-sweden/specifications/blob/main/request-parameter-extensions.md).
+
 <a name="attr-spec"></a>
 **\[OIDC.Sweden.Attr\]**
 > [Attribute Specification for the Swedish OpenID Connect Profile](https://github.com/oidc-sweden/specifications/blob/main/swedish-oidc-attribute-specification.md).
 
-<a name="oidc-profile"></a>
-**\[OIDC.Sweden.Profile\]**
-> [The Swedish OpenID Connect Profile](https://github.com/oidc-sweden/specifications/blob/main/swedish-oidc-profile.md).
 
 

--- a/request-parameter-extensions.md
+++ b/request-parameter-extensions.md
@@ -1,0 +1,234 @@
+![Logo](docs/images/oidc-logo.png)
+
+# Authentication Request Parameter Extensions for the Swedish OpenID Connect Profile
+
+### Version: 1.0 - draft 01 - 2023-04-27
+
+## Abstract
+
+This specification defines authentication request parameter extensions for the Swedish OpenID
+Connect Profile.
+
+## Table of Contents
+
+1. [**Introduction**](#introduction)
+
+    1.1. [Requirements Notation and Conventions](#requirements-notation-and-conventions)
+    
+    1.2. [Conformance](#conformance)    
+
+2. [**Authentication Request Parameter Extensions**](#authentication-request-parameter-extensions)
+	
+    2.1. [Client Provided User Message](#client-provided-user-message)
+    
+    2.2. [Requested Authentication Provider](#requested-authentication-provider)
+		
+3. [**Discovery Parameters**](#discovery-parameters)
+
+    3.1. [User Message Capabilities](#user-message-capabilities)
+    
+    3.1.1. [User Message Supported](#user-message-supported)
+    
+    3.1.2. [User Message Supported MIME Types](#user-message-supported-mime-types)
+    
+    3.2. [Requested Authentication Provider Capabilities](#requested-authentication-provider-capabilities)
+
+4. [**Normative References**](#normative-references)
+
+---
+
+<a name="introduction"></a>
+## 1. Introduction
+
+This specification defines authentication request parameter extensions for the Swedish OpenID
+Connect Profile. These parameters are OPTIONAL to support for both Relying Parties and OpenID
+Providers. The purpose of the request parameter extensions is to provide standardized solutions
+to commonly identified use cases, but support for any of these extensions are not needed to be
+compliant with the [The Swedish OpenID Connect Profile](#oidc-profile), 
+\[[OIDC.Sweden.Profile](#oidc-profile)\].
+
+<a name="requirements-notation-and-conventions"></a>
+### 1.1. Requirements Notation and Conventions
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” are to be interpreted as described in \[[RFC2119](#rfc2119)\].
+
+These keywords are capitalized when used to unambiguously specify requirements over protocol features and behavior that affect the interoperability and security of implementations. When these words are not capitalized, they are meant in their natural-language sense.
+
+<a name="conformance"></a>
+### 1.2. Conformance
+
+This profile defines requirements for OpenID Connect Relying Parties (clients) and OpenID Connect Providers (identity providers). Furthermore, it defines the interaction between a Relying Party and an OpenID Provider.
+
+When a component compliant with this profile is interacting with other components compliant with this profile, all components MUST fully conform to the features and requirements of this specification. Any interaction with components that are not compliant with this profile is out of scope for this specification.
+
+<a name="authentication-request-parameter-extensions"></a>
+## 2. Authentication Request Parameter Extensions
+
+This section defines authentication request parameters for some commonly identified use cases.
+The identifiers for all authentication request parameter extensions defined in this specification
+are prefixed with `https://id.oidc.se/param`.
+
+<a name="client-provided-user-message"></a>
+#### 2.1. Client Provided User Message
+
+**Parameter:** `https://id.oidc.se/param/userMessage`
+
+**Description:** When the user message claim is included in an authentication request, the issuing
+client requests that the OpenID Provider displays this message to the client in conjunction with
+the user authentication. 
+
+**Value type:** The value for the user message request parameter claim is a JSON object<sup>1</sup>
+ with the following fields:
+
+* `message` - A JSON-map where the keys are language tags (\[[RFC5646](#rfc5646)\]) and the map
+values are base64-encodings of the UTF-8 string holding the message to display to the user. The map
+MUST contain at least one language-message pair.
+
+* `mime_type` - The MIME type of the supplied message. This profile defines two possible values that
+are `text/plain` (where `;charset=UTF-8` is an implicit condition) and `text/markdown`<sup>2</sup>.
+If no value is given for this field, `text/plain` MUST be assumed. Other profiles MAY add support for
+additional MIME types. 
+
+**Requirements:** An OpenID Provider MUST NOT display a "user message" unless the user is being
+authenticated. Thus, if the request contains the `prompt` parameter with the value `none` (see
+section 2.1.4 of \[[OIDC.Sweden.Profile](#oidc-profile)\]), the OpenID Provider MUST NOT display
+the user message.
+
+This profile does not specify how the message should be displayed by the OpenID Provider, but if the
+`display` request parameter (see 3.1.2.1 of \[[OpenID.Core](#openid-core)\]) is included in the request,
+and supported by the OP, the provider SHOULD display the user message according to the value of the
+`display` parameter.
+
+The OpenID Provider MUST display the message matching the user interface locale that is in use. If no
+message matches that current locale, the OP MAY choose not to display any message, or select a message
+from the client provided map.
+
+An OpenID Provider MUST refuse to display a message if it does not support a given MIME type.
+
+Should a message contain illegal characters, or any other constructs not accepted by the provider,
+the OP MAY choose not to display the message, or filter the message before displaying it.
+
+**\[1\]:** The `https://id.oidc.se/param/userMessage` parameter value is represented in an
+authentication request as UTF-8 encoded JSON (which ends up being form-urlencoded when passed as a
+parameter). When used in a Request Object value, per section 6.1 of \[[OpenID.Core](#openid-core)\],
+the JSON is used as the value of the `https://id.oidc.se/param/userMessage` member.
+
+**\[2\]:** The Markdown dialect, and potential restrictions for tags, is not regulated in this specification.
+
+**Example:**
+
+```
+...
+"https://id.oidc.se/param/userMessage" : {  
+  "message" : { 
+    "sv" : "<Base64-encoded message in Swedish>",
+    "en" : "<Base64-encoded message in English>"
+  },
+  "mime_type" : "text/plain"
+},
+...
+```
+
+<a name="requested-authentication-provider"></a>
+#### 2.2. Requested Authentication Provider
+
+**Parameter:** `https://id.oidc.se/param/authnProvider`
+
+**Description:** In cases where the OpenID Provider can delegate, or proxy, the user 
+authentication to multiple authentication services, or if the OP offers multiple authentication
+mechanisms, the `authnProvider` request parameter MAY be used to inform the OP about 
+which of the authentication services, or mechanisms, that the Relying Party requests the user 
+to be authenticated at/with.
+
+An OpenID Provider that offers several different mechanisms for end-user
+authentication normally displays a dialogue from where the user selects how to authenticate.
+When the `authnProvider` request parameter is used, this interaction may be skipped.
+
+How possible values for this request parameter is announced by the OpenID Provider is
+out of scope for this specification. 
+
+Section 2.3.5 of \[[OIDC.Sweden.Attr](#attr-spec)\] defines the claim 
+`https://id.oidc.se/claim/authnProvider` that MAY be included in an ID token by an OpenID Provider.
+The value of this claim can be used by the Relying Party to request re-authentication of an end-user.
+By assigning the value to the `authnProvider` request parameter, the RP requests that the user is
+authenticated using the same authentication mechanism that he or she originally was authenticated with.
+
+**Value type:** String, preferably an URI
+
+<a name="discovery-parameters"></a>
+## 3. Discovery Parameters
+
+This section defines OpenID Connect discovery identifiers that are used to announce support
+for the authentication request parameters defined in this specification. All these identifiers
+are prefixed with `https://id.oidc.se/disco`.
+
+An OpenID Provider supporting any of the authentication request parameters defined in 
+[section 2](#authentication-request-parameter-extensions) MUST include the corresponding
+discovery parameter value, defined below, in its discovery document.
+
+<a name="user-message-capabilities"></a>
+### 3.1. User Message Capabilities
+
+This profile defines two OpenID Discovery parameters that may be used by OpenID Providers to announce support for 
+the `https://id.oidc.se/param/userMessage` authentication request parameter, see section 
+[2.1](#client-provided-user-message), [Client Provided User Message](#client-provided-user-message), above.
+
+<a name="user-message-supported"></a>
+#### 3.1.1. User Message Supported
+
+**Parameter:** `https://id.oidc.se/disco/userMessageSupported`
+
+**Description:** A discovery parameter specifying whether the OpenID Provider supports the 
+`https://id.oidc.se/param/userMessage` authentication request parameter, see section 
+[2.1](#client-provided-user-message), [Client Provided User Message](#client-provided-user-message),
+above.
+
+**Value type:** Boolean
+
+<a name="user-message-supported-mime-types"></a>
+#### 3.1.2. User Message Supported MIME Types
+
+**Parameter:** `https://id.oidc.se/disco/userMessageSupportedMimeTypes`
+
+**Description:** Holds the User Message MIME type(s) that is supported by the OpenID Provider.
+Its value is only relevant if `https://id.oidc.se/disco/userMessageSupported` is set to `true`
+(see above). 
+
+If this parameter is not set by the OP, a default of `[ "text/plain" ]` MUST be assumed.
+
+**Value type:** A JSON array of strings 
+
+<a name="requested-authentication-provider-capabilities"></a>
+### 3.2. Requested Authentication Provider Capabilities
+
+**Parameter:** `https://id.oidc.se/disco/authnProviderSupported`
+
+**Description:** A discovery parameter specifying whether the OpenID Provider supports the
+`https://id.oidc.se/param/authnProvider` authentication request parameter, see section
+[2.2](#requested-authentication-provider), 
+[Requested Authentication Provider](#requested-authentication-provider).
+
+**Value type:** Boolean
+
+<a name="normative-references"></a>
+## 4. Normative References
+
+<a name="rfc2119"></a>
+**\[RFC2119\]**
+> [Bradner, S., Key words for use in RFCs to Indicate Requirement Levels, March 1997](https://www.ietf.org/rfc/rfc2119.txt).
+
+<a name="openid-core"></a>
+**\[OpenID.Core\]**
+> [Sakimura, N., Bradley, J., Jones, M., de Medeiros, B. and C. Mortimore, "OpenID Connect Core 1.0", August 2015](https://openid.net/specs/openid-connect-core-1_0.html).
+
+<a name="rfc5646"></a>
+**\[RFC5646\]**
+> [Phillips, A. and M. Davis, “Tags for Identifying Languages,” BCP 47, RFC 5646, September 2009](https://www.rfc-editor.org/rfc/rfc5646).
+
+<a name="attr-spec"></a>
+**\[OIDC.Sweden.Attr\]**
+> [Attribute Specification for the Swedish OpenID Connect Profile](https://github.com/oidc-sweden/specifications/blob/main/swedish-oidc-attribute-specification.md).
+
+<a name="oidc-profile"></a>
+**\[OIDC.Sweden.Profile\]**
+> [The Swedish OpenID Connect Profile](https://github.com/oidc-sweden/specifications/blob/main/swedish-oidc-profile.md).

--- a/swedish-oidc-profile.md
+++ b/swedish-oidc-profile.md
@@ -2,7 +2,7 @@
 
 # The Swedish OpenID Connect Profile
 
-### Version: 1.0 - draft 02 - 2023-04-26
+### Version: 1.0 - draft 02 - 2023-04-27
 
 ## Abstract
 
@@ -35,16 +35,10 @@ This specification defines a profile for OpenID Connect for use within the Swedi
     2.1.7. [Request Objects (request and request_uri parameters)](#request-objects-request-and-request-uri-parameters)
     
 	2.1.8. [PKCE Parameters](#pkce-parameters)
-	
-	2.2. [Authentication Request Parameter Extensions](#authentication-request-parameter-extensions)
-	
-    2.2.1. [Client Provided User Message](#client-provided-user-message)
+		
+    2.2. [Processing of Authentication Requests](#processing-of-authentication-requests)
     
-    2.2.2. [Requested Authentication Provider](#requested-authentication-provider)
-	
-    2.3. [Processing of Authentication Requests](#processing-of-authentication-requests)
-    
-    2.4. [Authentication Responses](#authentication-responses)
+    2.3. [Authentication Responses](#authentication-responses)
 	
 3. [**Token Endpoint Requests and ID Token Issuance**](#token-endpoint-requests-and-id-token-issuance)
     
@@ -142,15 +136,13 @@ Relying Party to include in a request, and required or optional for an OP to sup
 | `request` | Request Object JWT. See [2.1.7](#request-objects-request-and-request-uri-parameters). | OPTIONAL for RP<br />REQUIRED for OP |
 | `request_uri` | Request Object JWT passed by reference. See [2.1.7](#request-objects-request-and-request-uri-parameters). | OPTIONAL |
 | `code_challenge`, `code_challenge_method` | Proof Key for Code Exchange (PKCE). See [2.1.8](#pkce-parameters) below. | OPTIONAL for RP<br />REQUIRED for OP |
-| `https://id.oidc.se/`<br />`param/userMessage` | Client provided user message. See [2.2.1](#client-provided-user-message) below. | OPTIONAL |
-| `https://id.oidc.se/`<br />`param/authnProvider` | Requested Authentication Provider. See [2.2.2](#requested-authentication-provider) below. | OPTIONAL
 
 <a name="the-scope-parameter"></a>
 #### 2.1.1. The scope Parameter
 
 The `scope` parameter value MUST contain `openid` and MAY contain additional scopes controlling required claims.
 
-See \[[AttrSpec](#attr-spec)\] for all the defined scopes for this profile, and section [4, Claims and Scopes](#claims-and-scopes), for the scopes that are mandatory to support.
+See \[[OIDC.Sweden.Attr](#attr-spec)\] for all the defined scopes for this profile, and section [4, Claims and Scopes](#claims-and-scopes), for the scopes that are mandatory to support.
 
 <a name="the-state-parameter"></a>
 #### 2.1.2. The state Parameter
@@ -240,104 +232,15 @@ An OpenID Provider compliant with this profile MUST support the PKCE extension i
 
 An OpenID Provider MUST NOT allow a Relying Party to use the `plain` code challenge method.
 
-<a name="authentication-request-parameter-extensions"></a>
-### 2.2. Authentication Request Parameter Extensions
-
-This section contains authentication request parameter extensions defined within the scope of this profile.
-
-<a name="client-provided-user-message"></a>
-#### 2.2.1. Client Provided User Message
-
-**Parameter:** `https://id.oidc.se/param/userMessage`
-
-**Description:** When the user message claim is included in an authentication request the issuing client requests
-that the OpenID Provider displays this message to the client in conjunction with the user authentication. 
-
-**Value type:** The value for the user message request parameter claim is a JSON object<sup>1</sup> 
-with the following fields:
-
-* `message` - A JSON-map where the keys are language tags (\[[RFC5646](#rfc5646)\]) and the map values are
-base64-encodings of the UTF-8 string holding the message to display to the user. The map MUST contain at least
-one language-message pair.
-
-* `mime_type` - The MIME type of the supplied message. This profile defines two possible values that are 
-`text/plain` (where `;charset=UTF-8` is an implicit condition) and `text/markdown`<sup>2</sup>. If no value
-is given for this field, `text/plain` MUST be assumed. Other profiles MAY add support for additional MIME 
-types. 
-
-**Requirements:** An OpenID Provider MUST NOT display a "user message" unless the user is being authenticated.
-Thus, if the request contains the `prompt` parameter with the value `none` (see 
-section [2.1.4](#the-prompt-parameter) above), the OpenID Provider MUST NOT display the user message.
-
-This profile does not specify how the message should be displayed by the OpenID Provider, but if the `display`
-request parameter (see 3.1.2.1 of \[[OpenID.Core](#openid-core)\]) is included in the request, and supported
-by the OP, the provider SHOULD display the user message according to the value of the `display` parameter.
-
-The OpenID Provider MUST display the message matching the user interface locale that is in use. If no message
-matches that current locale, the OP MAY choose not to display any message, or select a message from the
-client provided map.
-
-An OpenID Provider MUST refuse to display a message if it does not support a given MIME type.
-
-Should a message contain illegal characters, or any other constructs not accepted by the provider, the OP
-MAY choose not to display the message, or filter the message before displaying it.
-
-**\[1\]:** The `https://id.oidc.se/param/userMessage` parameter value is represented in an authentication request as 
-UTF-8 encoded JSON (which ends up being form-urlencoded when passed as a parameter). When used in a 
-Request Object value, per section 6.1 of \[[OpenID.Core](#openid-core)\], the JSON is used as the value of 
-the `https://id.oidc.se/param/userMessage` member.
-
-**\[2\]:** The Markdown dialect, and potential restrictions for tags, is not regulated in this specification.
-
-**Example:**
-
-```
-...
-"https://id.oidc.se/param/userMessage" : {  
-  "message" : { 
-    "sv" : "<Base64-encoded message in Swedish>",
-    "en" : "<Base64-encoded message in English>"
-  },
-  "mime_type" : "text/plain"
-},
-...
-```
-
-<a name="requested-authentication-provider"></a>
-#### 2.2.2. Requested Authentication Provider
-
-**Parameter:** `https://id.oidc.se/param/authnProvider`
-
-**Description:** In cases where the OpenID Provider can delegate, or proxy, the user 
-authentication to multiple authentication services, or if the OP offers multiple authentication
-mechanisms, the `authnProvider` request parameter MAY be used to inform the OP about 
-which of the authentication services, or mechanisms, that the Relying Party requests the user 
-to be authenticated at/with.
-
-An OpenID Provider that offers several different mechanisms for end-user
-authentication normally displays a dialogue from where the user selects how to authenticate.
-When the `authnProvider` request parameter is used, this interaction may be skipped.
-
-How possible values for this request parameter is announced by the OpenID Provider is
-out of scope for this profile. 
-
-Section 2.3.5 of \[[AttrSpec](#attr-spec)\] defines the claim `https://id.oidc.se/claim/authnProvider` 
-that MAY be included in an ID token by an OpenID Provider. The value of this claim can be used by the
-Relying Party to request re-authentication of an end-user. By assigning the value to the `authnProvider`
-request parameter, the RP requests that the user is authenticated using the same authentication mechanism
-that he or she originally was authenticated with.
-
-**Value type:** String, preferably an URI
-
 <a name="processing-of-authentication-requests"></a>
-### 2.3. Processing of Authentication Requests
+### 2.2. Processing of Authentication Requests
 
 An OpenID Provider compliant with this profile MUST follow the requirements stated in section 3.1.2.2 of \[[OpenID.Core](#openid-core)\] and the requirements put in [section 2.1](#authentication-request-parameters) of this profile.
 
 Furthermore, the OpenID Provider MUST not proceed with the authentication if the request contains the `acr_values` request parameter and none of the specified Requested Authentication Context Class Reference values can be used to authenticate the end-user. In these cases the provider SHOULD respond with an `unmet_authentication_requirements` error as defined in \[[OpenID.Unmet-AuthnReq](#openid-unmet-authnreq)\].
 
 <a name="authentication-responses"></a>
-### 2.4. Authentication Responses
+### 2.3. Authentication Responses
 
 Entities compliant with this profile MUST follow the requirements regarding authentication error
 responses put in section 3.1.2.6 of \[[OpenID.Core](#openid-core)\].
@@ -448,16 +351,16 @@ Relying Parties MUST follow the requirements in section [3.1.3.7] of \[[OpenID.C
 <a name="claims-and-scopes"></a>
 ## 4. Claims and Scopes
 
-The "Attribute Specification for the Swedish OpenID Connect Profile" document, \[[AttrSpec](#attr-spec)\], defines
+The "Attribute Specification for the Swedish OpenID Connect Profile" document, \[[OIDC.Sweden.Attr](#attr-spec)\], defines
 claims and scopes to be used by entities compliant with the Swedish OpenID Connect profile. 
 
 Additional claims and scopes may be defined in profiles extending this profile, but to stay compliant and thus ensure
-interoperability, a claim that represents an identity value that already has a definition in \[[AttrSpec](#attr-spec)\]
+interoperability, a claim that represents an identity value that already has a definition in \[[OIDC.Sweden.Attr](#attr-spec)\]
 MUST NOT be re-defined with a new claim name in profiles extending the Swedish OpenID Connect profile.
 
 > As an example: An OpenID Provider compliant with this profile MUST not invent its own claim definition of a Swedish
 personal identity number. It MUST use the `https://id.oidc.se/claim/personalIdentityNumber` defined in 
-\[[AttrSpec](#attr-spec)\].
+\[[OIDC.Sweden.Attr](#attr-spec)\].
 
 <a name="userinfo-endpoint"></a>
 ### 4.1. UserInfo Endpoint
@@ -481,9 +384,9 @@ Section 5.4 of \[[OpenID.Core](#openid-core)\] states:
 
 \[[OpenID.Core](#openid-core)\] basically assumes that the user identity is delivered in the `sub` claim that is part of the ID token, and all other attributes are complementary attributes that may be fetched in a later call to the UserInfo endpoint. 
 
-The Swedish OpenID Connect profile takes another approach regarding the primary user identity, and the primary user identity is most often represented by a claim delivered as part of a requested scope. Therefore, this profile, requires that if any of the scopes defined in section 3 of \[[AttrSpec](#attr-spec)\] are requested the corresponding claims MUST be delivered in the ID token<sup>3</sup>.
+The Swedish OpenID Connect profile takes another approach regarding the primary user identity, and the primary user identity is most often represented by a claim delivered as part of a requested scope. Therefore, this profile, requires that if any of the scopes defined in section 3 of \[[OIDC.Sweden.Attr](#attr-spec)\] are requested the corresponding claims MUST be delivered in the ID token<sup>3</sup>.
 
-"Authentication Information Claims" as defined in section 2.3 of \[[AttrSpec](#attr-spec)\] are claims
+"Authentication Information Claims" as defined in section 2.3 of \[[OIDC.Sweden.Attr](#attr-spec)\] are claims
 describing an authentication event, and are not user identity claims. Therefore, any of these claims
 MUST be delivered in the ID token and MUST NOT be delivered from the UserInfo endpoint.
 
@@ -533,55 +436,8 @@ An OpenID Provider compliant with this profile MUST present a discovery document
 | `claims_parameter_supported` | Boolean value specifying whether the OpenID Provider supports use of the `claims` request parameter. Since this profile requires support the value MUST be set to `true`. | REQUIRED |
 | `request_parameter_supported` | Boolean value specifying whether the OpenID Provider supports use of the `request` parameter for Request Objects. Since this profile requires support the value MUST be set to `true`. | REQUIRED |
 | `code_challenge_methods_supported` | JSON array containing a list of PKCE code challenge methods supported by this OP. The array MUST include the `S256` method and MUST NOT include the `plain` method.<br />The `code_challenge_methods_supported` parameter is defined in section 2 of \[[RFC8614](#rfc8614)\]. | REQUIRED |
-| `https://id.oidc.se/`<br />`disco/userMessageSupported` | Boolean value specifying whether the OP supports the `https://id.oidc.se/param/userMessage` authentication request parameter, see [5.3.1.1](#user-message-supported) below. An OP that supports the request parameter MUST set this value to `true`.<br />If this parameter is not present it MUST be interpreted as that the OP does not support the request parameter. | OPTIONAL |
-| `https://id.oidc.se/disco/`<br />`userMessageSupportedMimeTypes` | JSON array containing the list of supported MIME types for the `https://id.oidc.se/param/userMessage` authentication request parameter, see [5.3.1.2](#user-message-supported-mime-types) below. <br />If the `https://id.oidc.se/disco/userMessageSupported` parameter is set to `true` and this field is not present, a default of `[ "text/plain" ]` MUST be assumed. | OPTIONAL |
-| `https://id.oidc.se/disco/`<br />`authnProviderSupported` | Boolean value specifying whether the OP supports the `authnProvider` request parameter, see [5.3.2](#requested-authentication-provider-capabilities) below. | OPTIONAL |
-
 
 Any other fields specified in \[[OpenID.Discovery](#openid-discovery)\] not appearing in the table above MAY also be used.
-
-<a name="discovery-parameter-extensions"></a>
-### 5.3. Discovery Parameter Extensions
-
-This section contains discovery parameter extensions defined by this profile.
-
-<a name="user-message-capabilities"></a>
-#### 5.3.1. User Message Capabilities
-
-This profile defines two OpenID Discovery parameters that may be used by OpenID Providers to announce support for 
-the `https://id.oidc.se/param/userMessage` authentication request parameter, see section 
-[2.2.1](#client-provided-user-message), [Client Provided User Message](#client-provided-user-message), above.
-
-<a name="user-message-supported"></a>
-##### 5.3.1.1. User Message Supported
-
-**Parameter:** `https://id.oidc.se/disco/userMessageSupported`
-
-**Description:** A discovery parameter specifying whether the OpenID Provider supports the `https://id.oidc.se/param/userMessage` authentication request parameter, see section 
-[2.2.1](#client-provided-user-message), [Client Provided User Message](#client-provided-user-message), above.
-
-**Value type:** Boolean
-
-<a name="user-message-supported-mime-types"></a>
-##### 5.3.1.2. User Message Supported MIME Types
-
-**Parameter:** `https://id.oidc.se/disco/userMessageSupportedMimeTypes`
-
-**Description:** Holds the User Message MIME type(s) that is supported by the OpenID Provider. Its value is only
-relevant if `https://id.oidc.se/disco/userMessageSupported` is set to `true` (see above).
-
-**Value type:** A JSON array of strings 
-
-<a name="requested-authentication-provider-capabilities"></a>
-#### 5.3.2. Requested Authentication Provider Capabilities
-
-**Parameter:** `https://id.oidc.se/disco/authnProviderSupported`
-
-**Description:** A discovery parameter specifying whether the OpenID Provider supports the
-`https://id.oidc.se/param/authnProvider` authentication request parameter, see section
-[2.2.2](#requested-authentication-provider), [Requested Authentication Provider](#requested-authentication-provider).
-
-**Value type:** Boolean
 
 <a name="client-registration"></a>
 ## 6. Client Registration
@@ -682,14 +538,10 @@ An entity processing a message in which an algorithm not listed below has been u
 **\[RFC7636\]**
 > [Sakimura, N., Bradley, J. and N. Agarwal, "Proof Key for Code Exchange by OAuth Public Clients", RFC 7636, DOI 10.17487/RFC7636, September 2015](https://tools.ietf.org/html/rfc7636).
 
-<a name="rfc5646"></a>
-**\[RFC5646\]**
-> [Phillips, A. and M. Davis, “Tags for Identifying Languages,” BCP 47, RFC 5646, September 2009](https://www.rfc-editor.org/rfc/rfc5646).
-
-<a name=""></a>
+<a name="rfc5480"></a>
 **\[RFC5480\]**
 > [IETF RFC 5480, Elliptic Curve Cryptography Subject Public Key Information, March 2009](https://www.ietf.org/rfc/rfc5480.txt).
 
 <a name="attr-spec"></a>
-**\[AttrSpec\]**
+**\[OIDC.Sweden.Attr\]**
 > [Attribute Specification for the Swedish OpenID Connect Profile](https://github.com/oidc-sweden/specifications/blob/main/swedish-oidc-attribute-specification.md).


### PR DESCRIPTION
In order to be even more clear of what is required to be compliant with the Swedish OpenID Connect Profile we have moved the optional authentication request parameter extensions (including corresponding discovery fields) to a separate document, "Authentication Request Parameter Extensions for the Swedish OpenID Connect Profile".

@paxus42 

Closes #54 