### PR TITLE
IS-73 Change in representing languages on claims

### DIFF
--- a/oidc-signature-extension.md
+++ b/oidc-signature-extension.md
@@ -2,7 +2,7 @@
 
 # Signature Extension for OpenID Connect
 
-### Version: 1.0 - draft 02 - 2023-04-27
+### Version: 1.0 - draft 02 - 2023-10-18
 
 ## Abstract
 
@@ -138,10 +138,7 @@ part of the signature process<sup>2</sup>. The `sign_message` field is a JSON ob
 "https://id.oidc.se/param/signRequest" : {
   "tbs_data" : "<Base64-encoded data>",
   "sign_message" : {
-    "message" : { 
-      "sv" : "<Base64-encoded sign message in Swedish>",
-      "en" : "<Base64-encoded sign message in English>"
-    },
+    "message" : "<Base64-encoded sign message>",
     "mime_type" : "text/plain"
   }
 },
@@ -218,10 +215,8 @@ The following is a non-normative example of the claims in a Request Object befor
   "https://id.oidc.se/param/signRequest": {
     "tbs_data" : "VGhpcyBpcyB0aGUgZGF0YSB0aGF0IEkgd2FudCB0byBzaWdu",
     "sign_message" : {
-      "message" : { 
-        "sv" : "RGVubmEgdGV4dCB2aXNhcyBmw7ZyIGFudsOkbmRhcmVu",
-        "en" : "VGhpcyBpcyB0ZXh0IGRpc3BsYXllZCBmb3IgdGhlIHVzZXI="
-      },
+      "message#sv" : "RGVubmEgdGV4dCB2aXNhcyBmw7ZyIGFudsOkbmRhcmVu",
+      "message#en" : "VGhpcyBpcyB0ZXh0IGRpc3BsYXllZCBmb3IgdGhlIHVzZXI=",
       "mime_type" : "text/plain"
     }
   }

--- a/request-parameter-extensions.md
+++ b/request-parameter-extensions.md
@@ -119,7 +119,7 @@ the OP MAY choose not to display the message, or filter the message before displ
 ```
 ...
 "https://id.oidc.se/param/userMessage" : {  
-  "message" : "<Base64-encoded message>",  (language is undefined)
+  "message" : "<Base64-encoded message>",
   "mime_type" : "text/plain"
 },
 ...

--- a/request-parameter-extensions.md
+++ b/request-parameter-extensions.md
@@ -142,7 +142,7 @@ authentication request as UTF-8 encoded JSON (which ends up being form-urlencode
 parameter). When used in a Request Object value, per section 6.1 of \[[OpenID.Core](#openid-core)\],
 the JSON is used as the value of the `https://id.oidc.se/param/userMessage` member.
 
-**\[2\]:** The Markdown dialect, and potential restrictions for tags, is not regulated in this specification.
+**\[2\]:** The Markdown dialect, and potential restrictions for tags, is not regulated in this specification. However, the Markdown SHOULD NOT contain HTML-tags for security reasons.
 
 <a name="requested-authentication-provider"></a>
 #### 2.2. Requested Authentication Provider


### PR DESCRIPTION
In order to better comply with OIDC core's way of representing languages for claims, we have changed the definition on the userMessage request parameter.

Closes #73 