### PR TITLE
Feature/is 61 rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The oidc-sweden/specifications repository is where the Working Group for the Swe
 
 * [The Swedish OpenID Connect Profile 1.0 - draft](swedish-oidc-profile.md) - The main specification for the Swedish OpenID Connect profile.
 
-* [Attribute Specification for the Swedish OpenID Connect Profile 1.0 - draft](swedish-oidc-attribute-specification.md) - Claims and scopes.
+* [Claims and Scopes Specification for the Swedish OpenID Connect Profile 1.0 - draft](swedish-oidc-claims-specification.md) - Claims and scopes.
 
   * [How OpenID Connect Claims Map to other Specifications](claim-mappings-to-other-specs.md) - A non-normative listing of how OIDC claims map to some of the eID-systems in Sweden.
 

--- a/claim-mappings-to-other-specs.md
+++ b/claim-mappings-to-other-specs.md
@@ -90,7 +90,7 @@ The following table defines a mapping from the attribute names defined in "Freja
 
 <a name="oidc-sweden"></a>
 **\[OIDC.Sweden\]**
-> [Attribute Specification for the Swedish OpenID Connect Profile](https://www.oidc.se/specifications/swedish-oidc-attribute-specification.html).
+> [Claims and Scopes Specification for the Swedish OpenID Connect Profile](https://www.oidc.se/specifications/swedish-oidc-claims-specification.html).
 
 <a name="openid-core"></a>
 **\[OpenID.Core\]**

--- a/docs/claim-mappings-to-other-specs.html
+++ b/docs/claim-mappings-to-other-specs.html
@@ -465,7 +465,7 @@
 <p><a name="oidc-sweden"></a>
 <strong>[OIDC.Sweden]</strong></p>
 <blockquote>
-<p><a href="https://www.oidc.se/specifications/swedish-oidc-attribute-specification.html">Attribute Specification for the Swedish OpenID Connect Profile</a>.</p>
+<p><a href="https://www.oidc.se/specifications/swedish-oidc-claims-specification.html">Claims and Scopes Specification for the Swedish OpenID Connect Profile</a>.</p>
 </blockquote>
 <p><a name="openid-core"></a>
 <strong>[OpenID.Core]</strong></p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,7 +32,7 @@
     </p>
     <ul>
       <li>
-	<a href="swedish-oidc-profile.html">Version 1.0 - Draft 02</a>
+	<a href="swedish-oidc-profile.html">Version 1.0 - Draft</a>
       </li>
     </ul>
 
@@ -42,7 +42,7 @@
     </p>
     <ul>
       <li>
-	<a href="swedish-oidc-claims-specification.html">Version 1.0 - Draft 02</a>
+	<a href="swedish-oidc-claims-specification.html">Version 1.0 - Draft</a>
       </li>
     </ul>
     <blockquote>
@@ -57,7 +57,7 @@
     </p>
     <ul>
       <li>
-	<a href="request-parameter-extensions.html">Version 1.0 - Draft 01</a>
+	<a href="request-parameter-extensions.html">Version 1.0 - Draft</a>
       </li>
     </ul>
 
@@ -69,7 +69,7 @@
     </p>
     <ul>
       <li>
-	<a href="oidc-signature-extension.html">Version 1.0 - Draft 02</a>
+	<a href="oidc-signature-extension.html">Version 1.0 - Draft</a>
       </li>
     </ul>
     

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,13 +36,13 @@
       </li>
     </ul>
 
-    <h4>Attribute Specification for the Swedish OpenID Connect Profile</h4>
+    <h4>Claims and Scopes Specification for the Swedish OpenID Connect Profile</h4>
     <p>
       Specification that defines claims and scopes for the Swedish OpenID Connect profile.
     </p>
     <ul>
       <li>
-	<a href="swedish-oidc-attribute-specification.html">Version 1.0 - Draft 02</a>
+	<a href="swedish-oidc-claims-specification.html">Version 1.0 - Draft 02</a>
       </li>
     </ul>
     <blockquote>

--- a/docs/oidc-signature-extension.html
+++ b/docs/oidc-signature-extension.html
@@ -12,7 +12,7 @@
   <body>
     <article class="markdown-body"><p class="img-container"><img src="img/oidc-logo.png" alt="Logo"></p>
 <h1 id="signature-extension-for-openid-connect">Signature Extension for OpenID Connect</h1>
-<h3 id="version-10---draft-02---2023-10-18">Version: 1.0 - draft 02 - 2023-10-18</h3>
+<h3 id="version-10---draft-02---2023-10-20">Version: 1.0 - draft 02 - 2023-10-20</h3>
 <h2 id="abstract">Abstract</h2>
 <p>This specification defines an extension to OpenID Connect to facilitate use cases where a Relying Party sends a
 &quot;Signature Request&quot; to an OpenID Provider. A signature request is an extension of an OpenID Connect authentication
@@ -91,7 +91,7 @@ is being signed.</p>
 that actually supports eID:s that support creating signatures can be used.</p>
 <p><a name="identifiers"></a></p>
 <h2 id="3-identifiers">3. Identifiers</h2>
-<p>This section extends [<a href="#attr-spec">OIDC.Sweden.Attr</a>] with definitions of parameter claims and scopes used for the signing
+<p>This section extends [<a href="#claims-spec">OIDC.Sweden.Claims</a>] with definitions of parameter claims and scopes used for the signing
 use case defined in this specification.</p>
 <p><a name="the-signature-request-parameter"></a></p>
 <h3 id="31-the-signature-request-parameter">3.1. The Signature Request Parameter</h3>
@@ -149,7 +149,7 @@ Location: https:<span class="hljs-comment">//server.example.com/authorize?</span
   &amp;https%3A%2F%2Fid.oidc.se%2Fclaim%2FsignRequest=eyJhbjIn0.ew0...MbpL<span class="hljs-number">-2</span>QgwUsAlMGzw</code></pre><p>The scopes requested are <code>openid</code> (always) and <code>https://id.oidc.se/scope/sign</code> (see <a href="#signature-scope">section 3.2</a>, 
 <a href="#signature-scope">Signature Scope</a>)  that instructs the OpenID Provider that this is a signature request. 
 In a real-life scenario, the Relying Party would probably request additional claims using additional scopes, for example,
- <code>https://id.oidc.se/scope/naturalPersonNumber</code> and <code>https://id.oidc.se/scope/authnInfo</code> (see [<a href="#attr-spec">OIDC.Sweden.Attr</a>]).</p>
+ <code>https://id.oidc.se/scope/naturalPersonNumber</code> and <code>https://id.oidc.se/scope/authnInfo</code> (see [<a href="#claims-spec">OIDC.Sweden.Claims</a>]).</p>
 <p>The parameter <code>https://id.oidc.se/param/signRequest</code> is among the parameters and its value is a JWT
 (abbreviated for readability). This parameter value holds the input to the signature operation.</p>
 <blockquote>
@@ -227,7 +227,7 @@ included is a &quot;signature request&quot;, and it requests the claims declared
 <tbody><tr>
 <td align="left"><code>https://id.oidc.se/</code><br /><code>claim/userSignature</code></td>
 <td align="left">The signature that is the result of the user signing process at the OP.</td>
-<td align="left">[<a href="#attr-spec">OIDC.Sweden.Attr</a>]</td>
+<td align="left">[<a href="#claims-spec">OIDC.Sweden.Claims</a>]</td>
 <td align="left">REQUIRED</td>
 </tr>
 <tr>
@@ -328,7 +328,7 @@ claim, MUST be delivered in the ID Token and never from the UserInfo endpoint.</
 <p>OpenID Providers that are compliant with this specification<sup>1</sup>, MUST meet the following requirements discovery requirements:</p>
 <p>The <code>scopes_supported</code> MUST be present in the provider&#39;s discovery document and it MUST contain the scope 
 <code>https://id.oidc.se/scope/sign</code>.</p>
-<p>Also, it is RECOMMENDED that the <code>https://id.oidc.se/scope/authnInfo</code> scope is supported and declared. See [<a href="#attr-spec">OIDC.Sweden.Attr</a>].</p>
+<p>Also, it is RECOMMENDED that the <code>https://id.oidc.se/scope/authnInfo</code> scope is supported and declared. See [<a href="#claims-spec">OIDC.Sweden.Claims</a>].</p>
 <p>The <code>claims_supported</code> field MUST be present and include at least the claims that are included in the scope definitions for all
 declared scopes (in the <code>scopes_supported</code>).</p>
 <p>The <code>request_parameter_supported</code> MUST be present, and SHOULD be set to <code>true</code> (i.e., the OpenID Provider has support for 
@@ -383,10 +383,10 @@ If not declared, <code>[ &quot;text/plain&quot; ]</code> MUST be assumed.</p>
 <blockquote>
 <p><a href="https://www.oidc.se/specifications/swedish-oidc-profile.html">The Swedish OpenID Connect Profile</a>.</p>
 </blockquote>
-<p><a name="attr-spec"></a>
-<strong>[OIDC.Sweden.Attr]</strong></p>
+<p><a name="claims-spec"></a>
+<strong>[OIDC.Sweden.Claims]</strong></p>
 <blockquote>
-<p><a href="https://www.oidc.se/specifications/swedish-oidc-attribute-specification.html">Attribute Specification for the Swedish OpenID Connect Profile</a>.</p>
+<p><a href="https://www.oidc.se/specifications/swedish-oidc-claims-specification.html">Claims and Scopes Specification for the Swedish OpenID Connect Profile</a>.</p>
 </blockquote>
 <p><a name="request-ext"></a>
 <strong>[OIDC.Sweden.Params]</strong></p>

--- a/docs/request-parameter-extensions.html
+++ b/docs/request-parameter-extensions.html
@@ -12,7 +12,7 @@
   <body>
     <article class="markdown-body"><p class="img-container"><img src="img/oidc-logo.png" alt="Logo"></p>
 <h1 id="authentication-request-parameter-extensions-for-the-swedish-openid-connect-profile">Authentication Request Parameter Extensions for the Swedish OpenID Connect Profile</h1>
-<h3 id="version-10---draft-02---2023-10-18">Version: 1.0 - draft 02 - 2023-10-18</h3>
+<h3 id="version-10---draft-02---2023-10-20">Version: 1.0 - draft 02 - 2023-10-20</h3>
 <h2 id="abstract">Abstract</h2>
 <p>This specification defines authentication request parameter extensions for the Swedish OpenID
 Connect Profile.</p>
@@ -125,7 +125,7 @@ authentication normally displays a dialogue from where the user selects how to a
 When the <code>authnProvider</code> request parameter is used, this interaction may be skipped.</p>
 <p>How possible values for this request parameter is announced by the OpenID Provider is
 out of scope for this specification. </p>
-<p>Section 2.3.5 of [<a href="#attr-spec">OIDC.Sweden.Attr</a>] defines the claim 
+<p>Section 2.3.5 of [<a href="#claims-spec">OIDC.Sweden.Claims</a>] defines the claim 
 <code>https://id.oidc.se/claim/authnProvider</code> that MAY be included in an ID token by an OpenID Provider.
 The value of this claim can be used by the Relying Party to request re-authentication of an end-user.
 By assigning the value to the <code>authnProvider</code> request parameter, the RP requests that the user is
@@ -190,10 +190,10 @@ Its value is only relevant if <code>https://id.oidc.se/disco/userMessageSupporte
 <blockquote>
 <p><a href="https://www.rfc-editor.org/rfc/rfc5646">Phillips, A. and M. Davis, “Tags for Identifying Languages,” BCP 47, RFC 5646, September 2009</a>.</p>
 </blockquote>
-<p><a name="attr-spec"></a>
-<strong>[OIDC.Sweden.Attr]</strong></p>
+<p><a name="claims-spec"></a>
+<strong>[OIDC.Sweden.Claims]</strong></p>
 <blockquote>
-<p><a href="https://www.oidc.se/specifications/swedish-oidc-attribute-specification.html">Attribute Specification for the Swedish OpenID Connect Profile</a>.</p>
+<p><a href="https://www.oidc.se/specifications/swedish-oidc-claims-specification.html">Claims and Scopes Specification for the Swedish OpenID Connect Profile</a>.</p>
 </blockquote>
 <p><a name="oidc-profile"></a>
 <strong>[OIDC.Sweden.Profile]</strong></p>

--- a/docs/swedish-oidc-claims-specification.html
+++ b/docs/swedish-oidc-claims-specification.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Attribute Specification for the Swedish OpenID Connect Profile</title>
+    <title>Claims and Scopes Specification for the Swedish OpenID Connect Profile</title>
     <link type="text/css" rel="stylesheet" href="assets/css/github-markdown.css">
     <link type="text/css" rel="stylesheet" href="assets/css/pilcrow.css">
     <link type="text/css" rel="stylesheet" href="assets/css/oidc-portrait.css" media="print" >
@@ -11,8 +11,8 @@
   </head>
   <body>
     <article class="markdown-body"><p class="img-container"><img src="img/oidc-logo.png" alt="Logo"></p>
-<h1 id="attribute-specification-for-the-swedish-openid-connect-profile">Attribute Specification for the Swedish OpenID Connect Profile</h1>
-<h3 id="version-10---draft-02---2023-04-26">Version: 1.0 - draft 02 - 2023-04-26</h3>
+<h1 id="claims-and-scopes-specification-for-the-swedish-openid-connect-profile">Claims and Scopes Specification for the Swedish OpenID Connect Profile</h1>
+<h3 id="version-10---draft-03---2023-10-20">Version: 1.0 - draft 03 - 2023-10-20</h3>
 <h2 id="abstract">Abstract</h2>
 <p>This specification defines claims and scopes for the Swedish OpenID Connect profile.</p>
 <h2 id="table-of-contents">Table of Contents</h2>
@@ -65,7 +65,7 @@ representations (as is the case for the different SAML attribute specifications 
 <p>The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” are to be interpreted as described in [<a href="#rfc2119">RFC2119</a>].</p>
 <p>These keywords are capitalized when used to unambiguously specify requirements over protocol features and behavior that affect the interoperability and security of implementations. When these words are not capitalized, they are meant in their natural-language sense.</p>
 <p><a name="claims"></a></p>
-<h2 id="2-attributes-and-claims">2. Attributes and Claims</h2>
+<h2 id="2-claims">2. Claims</h2>
 <p>This specification defines a set of claims that extend the set of standard claims defined in [<a href="#rfc7515">RFC7515</a>] and 
 section 5.1 of [<a href="#openid-core">OpenID.Core</a>]. A full listing of standard claims can be found in the <a href="https://www.iana.org/assignments/jwt/jwt.xhtml#claims">IANA JSON Web Token Claims
 Registry</a>, [<a href="#iana-reg">IANA-Reg</a>].</p>

--- a/oidc-signature-extension.md
+++ b/oidc-signature-extension.md
@@ -2,7 +2,7 @@
 
 # Signature Extension for OpenID Connect
 
-### Version: 1.0 - draft 02 - 2023-10-18
+### Version: 1.0 - draft 02 - 2023-10-20
 
 ## Abstract
 
@@ -108,7 +108,7 @@ that actually supports eID:s that support creating signatures can be used.
 <a name="identifiers"></a>
 ## 3. Identifiers
 
-This section extends \[[OIDC.Sweden.Attr](#attr-spec)\] with definitions of parameter claims and scopes used for the signing
+This section extends \[[OIDC.Sweden.Claims](#claims-spec)\] with definitions of parameter claims and scopes used for the signing
 use case defined in this specification.
 
 <a name="the-signature-request-parameter"></a>
@@ -181,7 +181,7 @@ Location: https://server.example.com/authorize?
 The scopes requested are `openid` (always) and `https://id.oidc.se/scope/sign` (see [section 3.2](#signature-scope), 
 [Signature Scope](#signature-scope))  that instructs the OpenID Provider that this is a signature request. 
 In a real-life scenario, the Relying Party would probably request additional claims using additional scopes, for example,
- `https://id.oidc.se/scope/naturalPersonNumber` and `https://id.oidc.se/scope/authnInfo` (see \[[OIDC.Sweden.Attr](#attr-spec)\]).
+ `https://id.oidc.se/scope/naturalPersonNumber` and `https://id.oidc.se/scope/authnInfo` (see \[[OIDC.Sweden.Claims](#claims-spec)\]).
 
 The parameter `https://id.oidc.se/param/signRequest` is among the parameters and its value is a JWT
 (abbreviated for readability). This parameter value holds the input to the signature operation.
@@ -268,7 +268,7 @@ included is a "signature request", and it requests the claims declared in the ta
 
 | Claim | Description/comment | Reference | Requirement |
 | :--- | :--- | :--- | :--- |
-| `https://id.oidc.se/`<br />`claim/userSignature` | The signature that is the result of the user signing process at the OP. | \[[OIDC.Sweden.Attr](#attr-spec)\] | REQUIRED |
+| `https://id.oidc.se/`<br />`claim/userSignature` | The signature that is the result of the user signing process at the OP. | \[[OIDC.Sweden.Claims](#claims-spec)\] | REQUIRED |
 | `auth_time` | The time when the signature was created. | \[[OpenID.Core](#openid-core)\] | REQUIRED |
 
 **Note:** The `https://id.oidc.se/scope/sign` alone does not say anything about the identity of the signing end-user.
@@ -386,7 +386,7 @@ OpenID Providers that are compliant with this specification<sup>1</sup>, MUST me
 The `scopes_supported` MUST be present in the provider's discovery document and it MUST contain the scope 
 `https://id.oidc.se/scope/sign`.
 
-Also, it is RECOMMENDED that the `https://id.oidc.se/scope/authnInfo` scope is supported and declared. See \[[OIDC.Sweden.Attr](#attr-spec)\].
+Also, it is RECOMMENDED that the `https://id.oidc.se/scope/authnInfo` scope is supported and declared. See \[[OIDC.Sweden.Claims](#claims-spec)\].
 
 The `claims_supported` field MUST be present and include at least the claims that are included in the scope definitions for all
 declared scopes (in the `scopes_supported`).
@@ -442,9 +442,9 @@ If not declared, `[ "text/plain" ]` MUST be assumed.
 **\[OIDC.Sweden.Profile\]**
 > [The Swedish OpenID Connect Profile](https://www.oidc.se/specifications/swedish-oidc-profile.html).
 
-<a name="attr-spec"></a>
-**\[OIDC.Sweden.Attr\]**
-> [Attribute Specification for the Swedish OpenID Connect Profile](https://www.oidc.se/specifications/swedish-oidc-attribute-specification.html).
+<a name="claims-spec"></a>
+**\[OIDC.Sweden.Claims\]**
+> [Claims and Scopes Specification for the Swedish OpenID Connect Profile](https://www.oidc.se/specifications/swedish-oidc-claims-specification.html).
 
 <a name="request-ext"></a>
 **\[OIDC.Sweden.Params\]**

--- a/request-parameter-extensions.md
+++ b/request-parameter-extensions.md
@@ -2,7 +2,7 @@
 
 # Authentication Request Parameter Extensions for the Swedish OpenID Connect Profile
 
-### Version: 1.0 - draft 02 - 2023-10-18
+### Version: 1.0 - draft 02 - 2023-10-20
 
 ## Abstract
 
@@ -162,7 +162,7 @@ When the `authnProvider` request parameter is used, this interaction may be skip
 How possible values for this request parameter is announced by the OpenID Provider is
 out of scope for this specification. 
 
-Section 2.3.5 of \[[OIDC.Sweden.Attr](#attr-spec)\] defines the claim 
+Section 2.3.5 of \[[OIDC.Sweden.Claims](#claims-spec)\] defines the claim 
 `https://id.oidc.se/claim/authnProvider` that MAY be included in an ID token by an OpenID Provider.
 The value of this claim can be used by the Relying Party to request re-authentication of an end-user.
 By assigning the value to the `authnProvider` request parameter, the RP requests that the user is
@@ -244,9 +244,9 @@ If this parameter is not set by the OP, a default of `[ "text/plain" ]` MUST be 
 **\[RFC5646\]**
 > [Phillips, A. and M. Davis, “Tags for Identifying Languages,” BCP 47, RFC 5646, September 2009](https://www.rfc-editor.org/rfc/rfc5646).
 
-<a name="attr-spec"></a>
-**\[OIDC.Sweden.Attr\]**
-> [Attribute Specification for the Swedish OpenID Connect Profile](https://www.oidc.se/specifications/swedish-oidc-attribute-specification.html).
+<a name="claims-spec"></a>
+**\[OIDC.Sweden.Claims\]**
+> [Claims and Scopes Specification for the Swedish OpenID Connect Profile](https://www.oidc.se/specifications/swedish-oidc-claims-specification.html).
 
 <a name="oidc-profile"></a>
 **\[OIDC.Sweden.Profile\]**

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -27,7 +27,7 @@ INPUT_DIR=${1%/}
 OUTPUT_DIR=${2%/}
 
 declare -a SPECIFICATIONS=("swedish-oidc-profile.md"
-    "swedish-oidc-attribute-specification.md"
+    "swedish-oidc-claims-specification.md"
     "request-parameter-extensions.md"
     "oidc-signature-extension.md"
     "claim-mappings-to-other-specs.md")
@@ -39,10 +39,10 @@ for spec in "${SPECIFICATIONS[@]}"
 do
     echo "Processing ${spec} ..."
     ORIENTATION="p"
-    if [ "${spec}" == "xxx" ] || [ "${spec}" == "yyy" ];
-    then
-	ORIENTATION="l"
-    fi
+#    if [ "${spec}" == "xxx" ] || [ "${spec}" == "yyy" ];
+#    then
+#	ORIENTATION="l"
+#    fi
     ${INSTALL_DIR}/tohtml.sh ${INPUT_DIR}/"${spec}" ${OUTPUT_DIR} -o $ORIENTATION
 done
 

--- a/swedish-oidc-claims-specification.md
+++ b/swedish-oidc-claims-specification.md
@@ -1,8 +1,8 @@
 ![Logo](img/oidc-logo.png)
 
-# Attribute Specification for the Swedish OpenID Connect Profile
+# Claims and Scopes Specification for the Swedish OpenID Connect Profile
 
-### Version: 1.0 - draft 02 - 2023-04-26
+### Version: 1.0 - draft 03 - 2023-10-20
 
 ## Abstract
 
@@ -87,7 +87,7 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 These keywords are capitalized when used to unambiguously specify requirements over protocol features and behavior that affect the interoperability and security of implementations. When these words are not capitalized, they are meant in their natural-language sense.
 
 <a name="claims"></a>
-## 2. Attributes and Claims
+## 2. Claims
 
 This specification defines a set of claims that extend the set of standard claims defined in \[[RFC7515](#rfc7515)\] and 
 section 5.1 of \[[OpenID.Core](#openid-core)\]. A full listing of standard claims can be found in the [IANA JSON Web Token Claims


### PR DESCRIPTION
Renamed specification for claims to "Claims and Scopes Specification" from "Attribute Specification".

Closes #61 