### PR TITLE
IS-63 Removed generic claims such as country and birthName

### DIFF
--- a/claim-mappings-to-other-specs.md
+++ b/claim-mappings-to-other-specs.md
@@ -17,17 +17,17 @@ The following table defines a mapping from the SAML attribute names defined in "
 | Swedish Personal Number | urn:oid:1.2.752.29.4.13 (personalIdentityNumber) | `https://id.oidc.se/claim/`<br/>`personalIdentityNumber` | \[[OIDC.Sweden](#oidc-sweden)\] | \[[SC.AttrSpec](#sc-attrspec)\] also uses the same attribute for a Swedish coordination number. \[[OIDC.Sweden](#oidc-sweden)\] defines this claim to be `https://id.oidc.se/claim/coordinationNumber`. |
 | previousPersonal-<br/>IdentityNumber | urn:oid:1.2.752.201.3.15<br />(previousPersonalIdentityNumber) | `https://id.oidc.se/claim/`<br />`previousCoordinationNumber` | [[OIDC.Sweden](#oidc-sweden)\] | The OIDC-profile only handles coordination numbers. |
 | Date of birth | urn:oid:1.3.6.1.5.5.7.9.1 (dateOfBirth) | `birthdate` | \[[OpenID.Core](#openid-core)\] | The format (YYYY-MM-DD) is the same for both the dateOfBirth SAML-attribute and the `birthdate` claim. |
-| Name at the time of birth | urn:oid:1.2.752.201.3.8 (birthName) | `https://id.oidc.se/claim/`<br />`birthName` | \[[OIDC.Sweden](#oidc-sweden)\] | |
+| Name at the time of birth | urn:oid:1.2.752.201.3.8 (birthName) | `birth_family_name`<br />`birth_given_name`<br />`birth_middle_name` | \[[OIDC.IA](#oidc-ia)\] | |
 | Street address | urn:oid:2.5.4.9 (street) | `address.street_address` | \[[OpenID.Core](#openid-core)\] | Field of the `address` claim. |
 | Post office box | urn:oid:2.5.4.18 (postOfficeBox) | `address.street_address` | \[[OpenID.Core](#openid-core)\] | Field of the `address` claim. The `street_address` MAY include house number, street name, Post Office Box, and multi-line extended street address information.   |
 | Postal code | urn:oid:2.5.4.17 (postalCode) | `address.postal_code` | \[[OpenID.Core](#openid-core)\] | Field of the `address` claim. |
 | Locality | urn:oid:2.5.4.7 (l) | `address.locality` | \[[OpenID.Core](#openid-core)\] | Field of the `address` claim. |
-| Country | urn:oid:2.5.4.6 (c) | `address.country` or<br />`https://id.oidc.se/claim/`<br />`country` | \[[OpenID.Core](#openid-core)\]<br />\[[OIDC.Sweden](#oidc-sweden)\] | Depends on in which context country is to be represented. |
-| Place of birth | urn:oid:1.3.6.1.5.5.7.9.2 (placeOfBirth) | `https://id.oidc.se/claim/`<br />`placeOfbirth` | \[[OIDC.Sweden](#oidc-sweden)\] | |
+| Country | urn:oid:2.5.4.6 (c) | `address.country` | \[[OpenID.Core](#openid-core)\] | Depends on in which context country is to be represented. |
+| Place of birth | urn:oid:1.3.6.1.5.5.7.9.2 (placeOfBirth) | `place_of_birth` | \[[OIDC.IA](#oidc-ia)\] |  |
 | Country of citizenship | urn:oid:1.3.6.1.5.5.7.9.4 (countryOfCitizenship) | - | - | No mapping exists at this moment. |
 | Country of Residence | urn:oid:1.3.6.1.5.5.7.9.5 (countryOfResidence) | - | - | No mapping exists at this moment. |
 | Telephone number | urn:oid:2.5.4.20 (telephoneNumber) | `phone_number` | \[[OpenID.Core](#openid-core)\] | See also `phone_number_verified`. |
-| Mobile number | urn:oid:0.9.2342.19200300.100.1.41 (mobile) | `phone_number` | \[[OpenID.Core](#openid-core)\] | No specific claim exists that make a difference between a landline phone and a mobile phone in \[[IANA-Reg](#iana-reg)\]. Is this necessary? |
+| Mobile number | urn:oid:0.9.2342.19200300.100.1.41 (mobile) | `phone_number`<br />`msisdn` | \[[OpenID.Core](#openid-core)\]<br />\[[OIDC.IA](#oidc-ia)\] | |
 | E-mail address | urn:oid:0.9.2342.19200300.100.1.3 (mail) | `email` | \[[OpenID.Core](#openid-core)\] | See also `email_verified`. |
 | Organization name | urn:oid:2.5.4.10 (o) | `https://id.oidc.se/claim/`<br />`orgName` | \[[OIDC.Sweden](#oidc-sweden)\] |  |
 | Organizational unit name | urn:oid:2.5.4.11 (ou) | `https://id.oidc.se/claim/`<br />`orgUnit` | \[[OIDC.Sweden](#oidc-sweden)\] | |
@@ -95,6 +95,10 @@ The following table defines a mapping from the attribute names defined in "Freja
 <a name="openid-core"></a>
 **\[OpenID.Core\]**
 > [Sakimura, N., Bradley, J., Jones, M., de Medeiros, B. and C. Mortimore, "OpenID Connect Core 1.0", August 2015](https://openid.net/specs/openid-connect-core-1_0.html).
+
+<a name="oidc-ia"></a>
+**\[OIDC.IA\]**
+> [T. Lodderstedt, D. Fett, M. Haine, A. Pulido, K. Lehmann, K. Koiwai, "OpenID Connect for Identity Assurance 1.0", August 2022](https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html).
 
 <a name="iana-reg"></a>
 **\[IANA-Reg\]**

--- a/swedish-oidc-claims-specification.md
+++ b/swedish-oidc-claims-specification.md
@@ -44,16 +44,7 @@ This specification defines claims and scopes for the Swedish OpenID Connect prof
     2.3.4. [Authentication Evidence](#authentication-evidence)
 
     2.3.5. [Authentication Provider](#authentication-provider)
-    
-    2.4. [General Purpose Claims](#general-purpose-claims)
-
-    2.4.1. [Country](#country)
-    
-    2.4.2. [Birth Name](#birth-name)
-    
-    2.4.3. [Place of Birth](#place-of-birth)
-
-    2.4.4. [Age](#age) 
+     
 3. [**Scopes**](#scopes)
 
     3.1. [Natural Person Information](#natural-person-information)
@@ -331,51 +322,6 @@ we describe above.
 
 > **\[2\]:** These services, or authorities, do not necessarily have to be OpenID Providers, but 
 can be SAML Identity Providers, or any other authentication service.
-
-<a name="general-purpose-claims"></a>
-### 2.4. General Purpose Claims
-
-This section contains definitions of general purpose claims that do not fit into any of the above categories. 
-
-<a name="country"></a>
-#### 2.4.1. Country
-
-**Claim:** `https://id.oidc.se/claim/country`
-
-**Description:** \[[OpenID.Core](#openid-core)\] defines the `address` claim containing a `country` field, but
-there are many other areas where a country needs to be represented other than in the context of an individual's
-address. The `https://id.oidc.se/claim/country` claim is a general purpose claim that can be used to represent a country.
-
-**Type:** String. ISO 3166-1 alpha-2 \[[ISO3166](#iso3166)\] two letter country code.
-
-<a name="birth-name"></a>
-#### 2.4.2. Birth Name
-
-**Claim:** `https://id.oidc.se/claim/birthName`
-
-**Description:** Claims that corresponds to the `name` claim defined in \[[OpenID.Core](#openid-core)\] but is the
-full name at the time of birth for the subject.
-
-**Type:** String
-
-<a name="place-of-birth"></a>
-#### 2.4.3. Place of Birth
-
-**Claim:** `https://id.oidc.se/claim/placeOfbirth`
-
-**Description:** Claim representing the place of birth for the subject. This specification does not define "place".
-Depending on the context it may be "City" or "City, Country" or any other representation.
-
-**Type:** String 
-
-<a name="age"></a>
-#### 2.4.4. Age
-
-**Claim:** `https://id.oidc.se/claim/age`
-
-**Description:** Claim representing the age (in years) of the subject person.
-
-**Type:** Integer
 
 <a name="scopes"></a>
 ## 3. Scopes


### PR DESCRIPTION
These should not be defined in our specs. Also see "OpenID Connect for Identity Assurance 1.0" - https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html

Closes #63