### PR TITLE
Update discovery request parameter name

### DIFF
--- a/swedish-oidc-fed-profile.md
+++ b/swedish-oidc-fed-profile.md
@@ -260,7 +260,7 @@ The defined request parameters for a discovery request are:
 
 | Parameter       | Requirement | Type | Description |
 |:----------------| :-- | :-- | :-- |
-| `anchor`        |REQUIRED|Single value| The Trust Anchor the returned entities must resolve to.|
+| `trust_anchor`  |REQUIRED|Single value| The Trust Anchor the returned entities must resolve to.|
 | `type`          |OPTIONAL|One or more values | Specifies the requested entity types. An absent parameter is interpreted as all entity types.|
 | `trust_mark_id` |OPTIONAL|One or more values|Specifies the Trust Mark identifiers that must be supported by an entity for this entity to be included in the response.|
 


### PR DESCRIPTION
Change parameter name for discovery to reflect changes in resolve endpoint.

In accordance to OpenID Federation 1.0 - draft 41

Fixed #131: Changed anchor request parameter to trust_anchor, changed trust_anchor_id claim to trust_anchor, and changed type request parameter to entity_type.